### PR TITLE
Fixed #10 Update category name in referenceCategory field of SPDXlite.

### DIFF
--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -220,7 +220,7 @@ class SpdxLite:
                 'filesAnalyzed': False,
                 'copyrightText': 'NOASSERTION',
                 'externalRefs': [{
-                    'referenceCategory': 'PACKAGE_MANAGER',
+                    'referenceCategory': 'PACKAGE-MANAGER',
                     'referenceLocator': purl_ver,
                     'referenceType': 'purl'
                 }]


### PR DESCRIPTION
Reference Category field value "PACKAGE_MANAGER" is SPDX invalid. 

The standard defines it as "PACKAGE-MANAGER"

Fixes #10 