### PR TITLE
Scan Dependency Decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.9.0] - 2023-12-29
+### Added
+- Added dependency file decoration option to scanning (`scan`) using `--dep`
+  - More details can be found in [CLIENT_HELP.md](CLIENT_HELP.md)
+
 ## [1.8.0] - 2023-11-13
 ### Added
 - Added Component Decoration sub-command:
@@ -274,4 +279,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.2]: https://github.com/scanoss/scanoss.py/compare/v1.6.1...v1.6.2
 [1.6.3]: https://github.com/scanoss/scanoss.py/compare/v1.6.2...v1.6.3
 [1.7.0]: https://github.com/scanoss/scanoss.py/compare/v1.6.3...v1.7.0
-[1.7.0]: https://github.com/scanoss/scanoss.py/compare/v1.7.0...v1.8.0
+[1.8.0]: https://github.com/scanoss/scanoss.py/compare/v1.7.0...v1.8.0
+[1.9.0]: https://github.com/scanoss/scanoss.py/compare/v1.8.0...v1.9.0

--- a/CLIENT_HELP.md
+++ b/CLIENT_HELP.md
@@ -156,6 +156,22 @@ This fingerprint (WFP) can then be sent to the SCANOSS engine using the scanning
 scanoss-py scan -w src-fingers.wfp -o scan-results.json
 ```
 
+### Dependency file parsing
+The dependency files of a project can be fingerprinted/parsed using the `dep` command:
+```bash
+scanoss-py dep -o src-deps.json src
+```
+
+This parsed dependency file can then be sent to the SCANOSS for decoration using the scanning command:
+```bash
+scanoss-py scan --dep src-deps.json --dependencies-only -o scan-results.json
+```
+
+It is possible to combine a WFP & Dependency file into a single scan also:
+```bash
+scanoss-py scan -w src-fingers.wfp --dep src-deps.json -o scan-results.json
+```
+
 ### Scan a project folder
 The following command provides the capability to scan a given file/folder:
 ```bash
@@ -165,6 +181,12 @@ scanoss-py scan --help
 The following command scans the `src` folder and writes the output to `scan-results.json`:
 ```bash
 scanoss-py scan -o scan-results.json src
+```
+
+### Scan a project folder with dependencies
+The following command scans the `src` folder file, snippet & dependency matches, writing the output to `scan-results.json`:
+```bash
+scanoss-py scan -o scan-results.json -D src
 ```
 
 ### Converting RAW results into other formats

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@
    THE SOFTWARE.
 """
 
-__version__ = '1.8.1'
+__version__ = '1.9.0'

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@
    THE SOFTWARE.
 """
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'

--- a/src/scanoss/scancodedeps.py
+++ b/src/scanoss/scancodedeps.py
@@ -215,6 +215,26 @@ class ScancodeDeps(ScanossBase):
             self.print_stderr(f'ERROR: Issue running scancode dependency scan on {what_to_scan}: {e}')
             return False
         return True
+
+    def load_from_file(self, json_file: str = None) -> json:
+        """
+        Load the parsed JSON dependencies file and return the json object
+        :param json_file: dependency json file
+        :return: SCANOSS dependency JSON
+        """
+        if not json_file:
+            self.print_stderr('ERROR: No parsed JSON file provided to load.')
+            return None
+        if not os.path.isfile(json_file):
+            self.print_stderr(f'ERROR: parsed JSON file does not exist or is not a file: {json_file}')
+            return None
+        with open(json_file, 'r') as f:
+            try:
+                return json.loads(f.read())
+            except Exception as e:
+                self.print_stderr(f'ERROR: Problem loading input JSON: {e}')
+        return None
+
 #
 # End of ScancodeDeps Class
 #


### PR DESCRIPTION
- Added support to split dependency scanning from decoration
- A parse dependency file can now be supplied as part of a scan request
- Allows for separation of code from the actual scanning (air gap)