### PR TITLE
Handle missing license data during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.12.3] - 2024-05-13
+### Fixed
+- Fixed export issue when license details are missing (SPDX/CycloneDX)
+
 ## [1.12.2] - 2024-04-15
 ### Added
 - Added [tagging workflow](.github/workflows/version-tag.yml) to aid release generation
@@ -321,3 +325,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.12.0]: https://github.com/scanoss/scanoss.py/compare/v1.11.1...v1.12.0
 [1.12.1]: https://github.com/scanoss/scanoss.py/compare/v1.12.0...v1.12.1
 [1.12.2]: https://github.com/scanoss/scanoss.py/compare/v1.12.1...v1.12.2
+[1.12.3]: https://github.com/scanoss/scanoss.py/compare/v1.12.2...v1.12.3

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@
    THE SOFTWARE.
 """
 
-__version__ = '1.12.2'
+__version__ = '1.12.3'

--- a/src/scanoss/cyclonedx.py
+++ b/src/scanoss/cyclonedx.py
@@ -83,12 +83,13 @@ class CycloneDx(ScanossBase):
                             fd[field] = deps.get(field, '')
                         licenses = deps.get('licenses')
                         fdl = []
-                        dc = []
-                        for lic in licenses:
-                            name = lic.get("name")
-                            if name not in dc:  # Only save the license name once
-                                fdl.append({'id': name})
-                                dc.append(name)
+                        if licenses:
+                            dc = []
+                            for lic in licenses:
+                                name = lic.get("name")
+                                if name not in dc:  # Only save the license name once
+                                    fdl.append({'id': name})
+                                    dc.append(name)
                         fd['licenses'] = fdl
                         cdx[purl] = fd
                 else:
@@ -137,8 +138,9 @@ class CycloneDx(ScanossBase):
                         fd[field] = d.get(field)
                     licenses = d.get('licenses')
                     fdl = []
-                    for lic in licenses:
-                        fdl.append({'id': lic.get("name")})
+                    if licenses:
+                        for lic in licenses:
+                            fdl.append({'id': lic.get("name")})
                     fd['licenses'] = fdl
                     cdx[purl] = fd
         # self.print_stderr(f'VD: {vdx}')

--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -100,12 +100,13 @@ class SpdxLite:
                             fd[field] = deps.get(field, '')
                         licenses = deps.get('licenses')
                         fdl = []
-                        dc = []
-                        for lic in licenses:
-                            name = lic.get("name")
-                            if name not in dc:  # Only save the license name once
-                                fdl.append({'id': name})
-                                dc.append(name)
+                        if licenses:
+                            dc = []
+                            for lic in licenses:
+                                name = lic.get("name")
+                                if name not in dc:  # Only save the license name once
+                                    fdl.append({'id': name})
+                                    dc.append(name)
                         fd['licenses'] = fdl
                         summary[purl] = fd
                 else:  # Normal file id type
@@ -128,12 +129,13 @@ class SpdxLite:
                         fd[field] = d.get(field)
                     licenses = d.get('licenses')
                     fdl = []
-                    dc = []
-                    for lic in licenses:
-                        name = lic.get("name")
-                        if name not in dc:  # Only save the license name once
-                            fdl.append({'id': name})
-                            dc.append(name)
+                    if licenses:
+                        dc = []
+                        for lic in licenses:
+                            name = lic.get("name")
+                            if name not in dc:  # Only save the license name once
+                                fdl.append({'id': name})
+                                dc.append(name)
                     fd['licenses'] = fdl
                     summary[purl] = fd
         return summary


### PR DESCRIPTION
Handle missing license data during export to SPDX and CycloneDX.