### PR TITLE
Fix https://github.com/scanoss/scanoss.py/issues/48: add documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir /install
 WORKDIR /install
 ENV PATH=/root/.local/bin:$PATH
 
+# assumes `make dist` as prerequisite
 COPY ./dist/scanoss-*-py3-none-any.whl /install/
 
 # Install dependencies


### PR DESCRIPTION
Fix "Fatal error in Dockerfile from missing dist directory": add documentation on creating the dist directory

Signed-off-by: Lucas Gonze <lucas@gonze.com>
