### PR TITLE
#61 - Corrected SPDX date format

### DIFF
--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -183,7 +183,7 @@ class SpdxLite:
             'SPDXID': f'SPDXRef-{md5hex}',
             'name': 'SCANOSS-SBOM',
             'creationInfo': {
-                'created': now.strftime('%Y-%m-%dT%H:%M:%S') + now.strftime('.%f')[:4] + 'Z',
+                'created': now.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
                 'creators': [f'Tool: SCANOSS-PY: {__version__}', f'Person: {getpass.getuser()}']
             },
             'documentNamespace': f'https://spdx.org/spdxdocs/scanoss-py-{__version__}-{md5hex}',

--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -183,7 +183,7 @@ class SpdxLite:
             'SPDXID': f'SPDXRef-{md5hex}',
             'name': 'SCANOSS-SBOM',
             'creationInfo': {
-                'created': now.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+                'created': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
                 'creators': [f'Tool: SCANOSS-PY: {__version__}', f'Person: {getpass.getuser()}']
             },
             'documentNamespace': f'https://spdx.org/spdxdocs/scanoss-py-{__version__}-{md5hex}',


### PR DESCRIPTION
Changed line 186 in [spdxlite.py](https://github.com/scanoss/scanoss.py/blob/23f1eb36e27ad26b526d9ff68fcb17d5052b25cd/src/scanoss/spdxlite.py) to not include miliseconds in the timestamp field of SPDX-Lite output:

`'created': now.strftime('%Y-%m-%dT%H:%M:%SZ')`