### PR TITLE
Chore/groh/sp 1718 add supplier to spdx packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.17.2] - 2024-10-29
 ### Fixed
 - Fixed parsing of dependencies in Policy Checks
+### Added
+- Added supplier to SPDX packages
 
 ## [1.17.1] - 2024-10-24
 ### Fixed

--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -180,7 +180,7 @@ class SpdxLite:
         data = {
             'spdxVersion': 'SPDX-2.2',
             'dataLicense': 'CC0-1.0',
-            'SPDXID': f'SPDXRef-{md5hex}',
+            'SPDXID': f'SPDXRef-DOCUMENT',
             'name': 'SCANOSS-SBOM',
             'creationInfo': {
                 'created': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
@@ -214,6 +214,8 @@ class SpdxLite:
             comp_name = comp.get('component')
             comp_ver = comp.get('version')
             purl_ver = f'{purl}@{comp_ver}'
+            vendor = comp.get('vendor', 'NOASSERTION')
+            supplier = f"Organization: {vendor}" if vendor != 'NOASSERTION' else vendor
             purl_hash = hashlib.md5(f'{purl_ver}'.encode('utf-8')).hexdigest()
             purl_spdx = f'SPDXRef-{purl_hash}'
             data['documentDescribes'].append(purl_spdx)
@@ -227,6 +229,7 @@ class SpdxLite:
                 'licenseConcluded': 'NOASSERTION',
                 'filesAnalyzed': False,
                 'copyrightText': 'NOASSERTION',
+                'supplier':  supplier,
                 'externalRefs': [{
                     'referenceCategory': 'PACKAGE-MANAGER',
                     'referenceLocator': purl_ver,


### PR DESCRIPTION
### **What**

- Add supplier to SPDX packages
- Changes SPDXID Identifier. See [Documentation](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#63-spdx-identifier-field) 

This PR resolves: https://github.com/scanoss/scanoss.py/issues/63