### PR TITLE
feat: SP-1855 Use scanoss.json as default settings file

### DIFF
--- a/docs/source/scanoss_settings_schema.rst
+++ b/docs/source/scanoss_settings_schema.rst
@@ -173,3 +173,22 @@ Here's a complete example showing all sections:
             ]
         }
     }
+
+Usage
+-----
+
+You can pass the settings file path as an argument to the CLI
+
+.. code-block:: bash
+
+    $ scanoss-py scan . --settings /path/to/settings.json
+
+If no settings file is provided, the default settings file will be used.
+The default location for the settings file is ``scanoss.json`` in the current working directory.
+If this file does not exist, settings will be omitted.
+
+You can also skip the default settings file:
+
+.. code-block:: bash
+
+    $ scanoss-py scan . --skip-settings-file

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -33,7 +33,7 @@ from scanoss.utils.file import validate_json_file
 from .inspection.copyleft import Copyleft
 from .inspection.undeclared_component import UndeclaredComponent
 from .threadeddependencies import SCOPE
-from .scanoss_settings import DEFAULT_SCANOSS_JSON_FILE, ScanossSettings
+from .scanoss_settings import ScanossSettings, ScanossSettingsError
 from .scancodedeps import ScancodeDeps
 from .scanner import Scanner
 from .scantype import ScanType
@@ -575,7 +575,8 @@ def scan(parser, args):
                 scan_settings.load_json_file(args.ignore).set_file_type('legacy').set_scan_type('blacklist')
             else:
                 scan_settings.load_json_file(args.settings).set_file_type('new').set_scan_type('identify')
-        except Exception:
+        except ScanossSettingsError as e:
+            print_stderr(f'Error: {e}')
             exit(1)
 
     if args.dep:
@@ -584,9 +585,9 @@ def scan(parser, args):
                 f'Specified --dep file does not exist or is not a file: {args.dep}'
             )
             exit(1)
-        is_valid, error = validate_json_file(args.dep)
-        if not is_valid:
-            print_stderr(f'Error: Dependency file is not valid: {error}')
+        result = validate_json_file(args.dep)
+        if not result.is_valid:
+            print_stderr(f'Error: Dependency file is not valid: {result.error}')
             exit(1)
     if args.strip_hpsm and not args.hpsm and not args.quiet:
         print_stderr(

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -117,7 +117,7 @@ def setup_args() -> None:
         help='Settings file to use for scanning (optional - default scanoss.json)',
     )
     p_scan.add_argument(
-        '--omit-settings-file',
+        '--skip-settings-file',
         action='store_true',
         help='Omit default settings file (scanoss.json) if it exists',
     )
@@ -559,7 +559,7 @@ def scan(parser, args):
         exit(1)
         
     if args.settings and args.omit_settings_file:
-        print_stderr('ERROR: Cannot specify both --settings and --omit-file-settings options.')
+        print_stderr('ERROR: Cannot specify both --settings and --skip-file-settings options.')
         exit(1)
         
     scan_settings = None

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -558,13 +558,13 @@ def scan(parser, args):
         print_stderr('ERROR: Cannot specify both --identify and --settings options.')
         exit(1)
         
-    if args.settings and args.omit_settings_file:
+    if args.settings and args.skip_settings_file:
         print_stderr('ERROR: Cannot specify both --settings and --skip-file-settings options.')
         exit(1)
         
     scan_settings = None
                 
-    if args.omit_settings_file:
+    if args.skip_settings_file:
         print_stderr('Omit settings file is set. Skipping...')
     else:
         scan_settings = ScanossSettings(debug=args.debug, trace=args.trace, quiet=args.quiet)
@@ -584,9 +584,9 @@ def scan(parser, args):
                 f'Specified --dep file does not exist or is not a file: {args.dep}'
             )
             exit(1)
-        try:
-            validate_json_file(args.dep)
-        except Exception:
+        is_valid, error = validate_json_file(args.dep)
+        if not is_valid:
+            print_stderr(f'Error: Dependency file is not valid: {error}')
             exit(1)
     if args.strip_hpsm and not args.hpsm and not args.quiet:
         print_stderr(

--- a/src/scanoss/scanner.py
+++ b/src/scanoss/scanner.py
@@ -32,6 +32,8 @@ from progress.bar import Bar
 from progress.spinner import Spinner
 from pypac.parser import PACFile
 
+from scanoss.utils.file import validate_json_file
+
 from .scanossapi import ScanossApi
 from .cyclonedx import CycloneDx
 from .spdxlite import SpdxLite
@@ -96,18 +98,44 @@ class Scanner(ScanossBase):
     Handle the scanning of files, snippets and dependencies
     """
 
-    def __init__(self, wfp: str = None, scan_output: str = None, output_format: str = 'plain',
-                 debug: bool = False, trace: bool = False, quiet: bool = False, api_key: str = None, url: str = None,
-                 flags: str = None, nb_threads: int = 5,
-                 post_size: int = 32, timeout: int = 180, no_wfp_file: bool = False,
-                 all_extensions: bool = False, all_folders: bool = False, hidden_files_folders: bool = False,
-                 scan_options: int = 7, sc_timeout: int = 600, sc_command: str = None, grpc_url: str = None,
-                 obfuscate: bool = False, ignore_cert_errors: bool = False, proxy: str = None, grpc_proxy: str = None,
-                 ca_cert: str = None, pac: PACFile = None, retry: int = 5, hpsm: bool = False,
-                 skip_size: int = 0, skip_extensions=None, skip_folders=None,
-                 strip_hpsm_ids=None, strip_snippet_ids=None, skip_md5_ids=None,
-                 scan_settings: ScanossSettings = None
-                 ):
+    def __init__(
+        self,
+        wfp: str = None,
+        scan_output: str = None,
+        output_format: str = 'plain',
+        debug: bool = False,
+        trace: bool = False,
+        quiet: bool = False,
+        api_key: str = None,
+        url: str = None,
+        flags: str = None,
+        nb_threads: int = 5,
+        post_size: int = 32,
+        timeout: int = 180,
+        no_wfp_file: bool = False,
+        all_extensions: bool = False,
+        all_folders: bool = False,
+        hidden_files_folders: bool = False,
+        scan_options: int = 7,
+        sc_timeout: int = 600,
+        sc_command: str = None,
+        grpc_url: str = None,
+        obfuscate: bool = False,
+        ignore_cert_errors: bool = False,
+        proxy: str = None,
+        grpc_proxy: str = None,
+        ca_cert: str = None,
+        pac: PACFile = None,
+        retry: int = 5,
+        hpsm: bool = False,
+        skip_size: int = 0,
+        skip_extensions=None,
+        skip_folders=None,
+        strip_hpsm_ids=None,
+        strip_snippet_ids=None,
+        skip_md5_ids=None,
+        scan_settings: ScanossSettings = None
+    ):
         """
         Initialise scanning class, including Winnowing, ScanossApi, ThreadedScanning
         """
@@ -255,27 +283,7 @@ class Scanner(ScanossBase):
                     if WFP_FILE_START in line:
                         count += 1
         return count
-
-    @staticmethod
-    def valid_json_file(json_file: str) -> bool:
-        """
-        Validate if the specified file is indeed valid JSON
-        :param: str JSON file to load
-        :return bool True if valid, False otherwise
-        """
-        if not json_file:
-            Scanner.print_stderr('ERROR: No JSON file provided to parse.')
-            return False
-        if not os.path.isfile(json_file):
-            Scanner.print_stderr(f'ERROR: JSON file does not exist or is not a file: {json_file}')
-            return False
-        try:
-            with open(json_file) as f:
-                json.load(f)
-        except Exception as e:
-            Scanner.print_stderr(f'Problem parsing JSON file "{json_file}": {e}')
-            return False
-        return True
+    
 
     @staticmethod
     def version_details() -> str:

--- a/src/scanoss/scanner.py
+++ b/src/scanoss/scanner.py
@@ -32,8 +32,6 @@ from progress.bar import Bar
 from progress.spinner import Spinner
 from pypac.parser import PACFile
 
-from scanoss.utils.file import validate_json_file
-
 from .scanossapi import ScanossApi
 from .cyclonedx import CycloneDx
 from .spdxlite import SpdxLite

--- a/src/scanoss/scanoss_settings.py
+++ b/src/scanoss/scanoss_settings.py
@@ -43,8 +43,9 @@ class ScanossSettingsError(Exception):
 
 
 class ScanossSettings(ScanossBase):
-    """Handles the loading and parsing of the SCANOSS settings file"""
-
+    """
+    Handles the loading and parsing of the SCANOSS settings file
+    """
     def __init__(
         self,
         debug: bool = False,
@@ -64,37 +65,34 @@ class ScanossSettings(ScanossBase):
         self.data = {}
         self.settings_file_type = None
         self.scan_type = None
-
         if filepath:
             self.load_json_file(filepath)
 
     def load_json_file(self, filepath: str) -> 'ScanossSettings':
-        """Load the scan settings file. If no filepath is provided, scanoss.json will be used as default.
+        """
+        Load the scan settings file. If no filepath is provided, scanoss.json will be used as default.
 
         Args:
             filepath (str): Path to the SCANOSS settings file
         """
-
         if not filepath:
             filepath = DEFAULT_SCANOSS_JSON_FILE
-
         json_file = Path(filepath).resolve()
 
         if filepath == DEFAULT_SCANOSS_JSON_FILE and not json_file.exists():
-            self.print_debug(f"Default settings file '{filepath}' not found. Skipping...")
+            self.print_debug(f'Default settings file "{filepath}" not found. Skipping...')
             return self
+        self.print_msg(f'Loading settings file {filepath}...')
 
         result = validate_json_file(json_file)
         if not result.is_valid:
             raise ScanossSettingsError(f'Problem with settings file. {result.error}')
-
         self.data = result.data
-        self.print_debug(f'Loading scan settings from: {filepath}')
         return self
 
     def set_file_type(self, file_type: str):
-        """Set the file type in order to support both legacy SBOM.json and new scanoss.json files
-
+        """
+        Set the file type in order to support both legacy SBOM.json and new scanoss.json files
         Args:
             file_type (str): 'legacy' or 'new'
 
@@ -107,8 +105,8 @@ class ScanossSettings(ScanossBase):
         return self
 
     def set_scan_type(self, scan_type: str):
-        """Set the scan type to support legacy SBOM.json files
-
+        """
+        Set the scan type to support legacy SBOM.json files
         Args:
             scan_type (str): 'identify' or 'exclude'
         """
@@ -116,8 +114,8 @@ class ScanossSettings(ScanossBase):
         return self
 
     def _is_valid_sbom_file(self):
-        """Check if the scan settings file is valid
-
+        """
+        Check if the scan settings file is valid
         Returns:
             bool: True if the file is valid, False otherwise
         """
@@ -126,8 +124,8 @@ class ScanossSettings(ScanossBase):
         return True
 
     def _get_bom(self):
-        """Get the Billing of Materials from the settings file
-
+        """
+        Get the Billing of Materials from the settings file
         Returns:
             dict: If using scanoss.json
             list: If using SBOM.json
@@ -142,8 +140,8 @@ class ScanossSettings(ScanossBase):
         return self.data.get('bom', {})
 
     def get_bom_include(self) -> List[BomEntry]:
-        """Get the list of components to include in the scan
-
+        """
+        Get the list of components to include in the scan
         Returns:
             list: List of components to include in the scan
         """
@@ -152,8 +150,8 @@ class ScanossSettings(ScanossBase):
         return self._get_bom().get('include', [])
 
     def get_bom_remove(self) -> List[BomEntry]:
-        """Get the list of components to remove from the scan
-
+        """
+        Get the list of components to remove from the scan
         Returns:
             list: List of components to remove from the scan
         """
@@ -162,8 +160,8 @@ class ScanossSettings(ScanossBase):
         return self._get_bom().get('remove', [])
 
     def get_bom_replace(self) -> List[BomEntry]:
-        """Get the list of components to replace in the scan
-
+        """
+        Get the list of components to replace in the scan
         Returns:
             list: List of components to replace in the scan
         """
@@ -172,8 +170,8 @@ class ScanossSettings(ScanossBase):
         return self._get_bom().get('replace', [])
 
     def get_sbom(self):
-        """Get the SBOM to be sent to the SCANOSS API
-
+        """
+        Get the SBOM to be sent to the SCANOSS API
         Returns:
             dict: SBOM request payload
         """
@@ -185,8 +183,8 @@ class ScanossSettings(ScanossBase):
         }
 
     def _get_sbom_assets(self):
-        """Get the SBOM assets
-
+        """
+        Get the SBOM assets
         Returns:
             List: List of SBOM assets
         """
@@ -203,11 +201,10 @@ class ScanossSettings(ScanossBase):
 
     @staticmethod
     def normalize_bom_entries(bom_entries) -> List[BomEntry]:
-        """Normalize the BOM entries
-
+        """
+        Normalize the BOM entries
         Args:
             bom_entries (List[Dict]): List of BOM entries
-
         Returns:
             List: Normalized BOM entries
         """
@@ -222,11 +219,10 @@ class ScanossSettings(ScanossBase):
 
     @staticmethod
     def _remove_duplicates(bom_entries: List[BomEntry]) -> List[BomEntry]:
-        """Remove duplicate BOM entries
-
+        """
+        Remove duplicate BOM entries
         Args:
             bom_entries (List[Dict]): List of BOM entries
-
         Returns:
             List: List of unique BOM entries
         """

--- a/src/scanoss/scanoss_settings.py
+++ b/src/scanoss/scanoss_settings.py
@@ -80,10 +80,9 @@ class ScanossSettings(ScanossBase):
             self.print_debug(f'Default settings file not found: {filepath}. Skipping...')
             return self
 
-        try:
-            validate_json_file(json_file)
-        except ValueError as e:
-            return self.print_stderr(f'ERROR: Problem with settings file. {e}')
+        is_valid, error = validate_json_file(json_file)
+        if not is_valid:
+            return self.print_stderr(f'ERROR: Problem with settings file. {error}')
 
         with open(json_file, 'r') as jsonfile:
             self.print_debug(f'Loading scan settings from: {filepath}')

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -81,6 +81,11 @@ class ScanPostProcessor(ScanossBase):
         Returns:
             dict: Processed results
         """
+        if self.scan_settings.is_legacy():
+            self.print_stderr(
+                'Legacy settings file detected. Post-processing is not supported for legacy settings file.'
+            )
+            return self.results
         self._remove_dismissed_files()
         self._replace_purls()
         return self.results

--- a/src/scanoss/utils/__init__.py
+++ b/src/scanoss/utils/__init__.py
@@ -1,0 +1,23 @@
+"""
+SPDX-License-Identifier: MIT
+
+  Copyright (c) 2024, SCANOSS
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+"""

--- a/src/scanoss/utils/file.py
+++ b/src/scanoss/utils/file.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from typing import Tuple
 
 
 def print_stderr(*args, **kwargs):
@@ -25,21 +26,22 @@ def is_valid_file(file_path: str) -> bool:
     return True
 
 
-def validate_json_file(json_file_path: str) -> None:
+def validate_json_file(json_file_path: str) -> Tuple[bool, str]:
     """Validate if the specified file is indeed a valid JSON file
 
     Args:
         json_file_path (str): The JSON file to validate
 
-    Raises:
-        ValueError: If the JSON file is not valid
+    Returns:
+        Tuple[bool, str]: A tuple containing a boolean indicating if the file is valid and a message
     """
     if not json_file_path:
-        raise ValueError('No JSON file provided to parse.')
+        return False, 'No JSON file provided to parse.'
     if not os.path.isfile(json_file_path):
-        raise ValueError(f'JSON file does not exist or is not a file: {json_file_path}')
+        return False, f'JSON file does not exist or is not a file: {json_file_path}'
     try:
         with open(json_file_path) as f:
             json.load(f)
+            return True, ''
     except Exception as e:
-        raise ValueError(f'Problem parsing JSON file "{json_file_path}": {e}') from e
+        return False, f'Problem parsing JSON file "{json_file_path}": {e}'

--- a/src/scanoss/utils/file.py
+++ b/src/scanoss/utils/file.py
@@ -1,0 +1,45 @@
+import json
+import os
+import sys
+
+
+def print_stderr(*args, **kwargs):
+    """
+    Print the given message to STDERR
+    """
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def is_valid_file(file_path: str) -> bool:
+    """Check if the specified file exists and is a file
+
+    Args:
+        file_path (str): The file path
+
+    Returns:
+        bool: True if valid, False otherwise
+    """
+    if not os.path.exists(file_path) or not os.path.isfile(file_path):
+        print_stderr(f'Specified file does not exist or is not a file: {file_path}')
+        return False
+    return True
+
+
+def validate_json_file(json_file_path: str) -> None:
+    """Validate if the specified file is indeed a valid JSON file
+
+    Args:
+        json_file_path (str): The JSON file to validate
+
+    Raises:
+        ValueError: If the JSON file is not valid
+    """
+    if not json_file_path:
+        raise ValueError('No JSON file provided to parse.')
+    if not os.path.isfile(json_file_path):
+        raise ValueError(f'JSON file does not exist or is not a file: {json_file_path}')
+    try:
+        with open(json_file_path) as f:
+            json.load(f)
+    except Exception as e:
+        raise ValueError(f'Problem parsing JSON file "{json_file_path}": {e}') from e

--- a/src/scanoss/utils/file.py
+++ b/src/scanoss/utils/file.py
@@ -1,7 +1,8 @@
 import json
 import os
 import sys
-from typing import Tuple
+from dataclasses import dataclass
+from typing import Optional
 
 
 def print_stderr(*args, **kwargs):
@@ -26,7 +27,14 @@ def is_valid_file(file_path: str) -> bool:
     return True
 
 
-def validate_json_file(json_file_path: str) -> Tuple[bool, str]:
+@dataclass
+class JsonValidation:
+    is_valid: bool
+    data: Optional[dict] = None
+    error: Optional[str] = None
+
+
+def validate_json_file(json_file_path: str) -> JsonValidation:
     """Validate if the specified file is indeed a valid JSON file
 
     Args:
@@ -36,12 +44,12 @@ def validate_json_file(json_file_path: str) -> Tuple[bool, str]:
         Tuple[bool, str]: A tuple containing a boolean indicating if the file is valid and a message
     """
     if not json_file_path:
-        return False, 'No JSON file provided to parse.'
+        return JsonValidation(is_valid=False, error='No JSON file specified')
     if not os.path.isfile(json_file_path):
-        return False, f'JSON file does not exist or is not a file: {json_file_path}'
+        return JsonValidation(is_valid=False, error=f'File not found: {json_file_path}')
     try:
         with open(json_file_path) as f:
-            json.load(f)
-            return True, ''
-    except Exception as e:
-        return False, f'Problem parsing JSON file "{json_file_path}": {e}'
+            data = json.load(f)
+            return JsonValidation(is_valid=True, data=data)
+    except json.JSONDecodeError as e:
+        return JsonValidation(is_valid=False, error=f'Problem parsing JSON file: "{json_file_path}": {e}')


### PR DESCRIPTION
## What
- Use `scanoss.json` as default settings file if no argument is supplied
- Add `—skip-settings-file` flag
- Throw errors if fails to parse json file, or if file does not exist (and move this into a common utils file)
- Added check for legacy `sbom.json` file in post processor

### How to test
- If specifying a settings file:
    - Run `scanoss-py scan .  —settings scanoss.json`
    - Run `scanoss-py scan . —settings custom-settings-file-name.json`
- If not specifying a settings file:
    - Run `scanoss-py scan .`
        - Should use scanoss.json as default (if it does not exist, it will skip it)
- If you want to skip the default settings file:
    - Run `scanoss-py scan . —skip-file-settings`