### PR TITLE
DO-160 / Change documentation theme to 'sphinx_rtd_theme' for integrated search across subprojects

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,1 +1,1 @@
-furo
+sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ author = 'Scan Open Source Solutions SL'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = ['sphinx_rtd_theme']
 
 templates_path = ["_templates"]
 exclude_patterns = []
@@ -24,7 +24,7 @@ exclude_patterns = []
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 
-html_theme = 'furo'
+html_theme = 'sphinx_rtd_theme'
 html_logo = 'scanosslogo.jpg'
 html_static_path = ['_static']
 


### PR DESCRIPTION
Updated documentation theme to 'sphinx_rtd_theme' to enable integrated search across SCANOSS documentation.