### PR TITLE
chore: update dockerfile to use python 3.10-slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.20.4] - 2025-03-05
+### Modified
+- Updated Dockerfile to use Python 3.10-slim
+
 ## [1.20.3] - 2025-03-03
 ### Fixed
 - Fixed cli.py typo
@@ -472,3 +476,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.20.1]: https://github.com/scanoss/scanoss.py/compare/v1.20.0...v1.20.1
 [1.20.2]: https://github.com/scanoss/scanoss.py/compare/v1.20.1...v1.20.2
 [1.20.3]: https://github.com/scanoss/scanoss.py/compare/v1.20.2...v1.20.3
+[1.20.4]: https://github.com/scanoss/scanoss.py/compare/v1.20.3...v1.20.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:3.10-slim-buster AS base
+FROM --platform=$BUILDPLATFORM python:3.10-slim AS base
 
 LABEL maintainer="SCANOSS <infra@scanoss.com>"
 LABEL org.opencontainers.image.source=https://github.com/scanoss/scanoss.py

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.20.3'
+__version__ = '1.20.4'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes to feature version 1.20.4 with a new comparison link for detailed release insights.
  
- **Chores**
  - Upgraded the runtime configuration for a streamlined build process.
  - Bumped the software version to 1.20.4 for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->