### PR TITLE
Bug/jortiz/spdxlite output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.20.5] - 2025-03-13
+### Added
+- Improved documentation on spdxlite.py file
+### Modified
+- Added validation for license source on SPDXLite output format
+
 ## [1.20.4] - 2025-03-05
 ### Modified
 - Updated Dockerfile to use Python 3.10-slim
@@ -477,3 +483,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.20.2]: https://github.com/scanoss/scanoss.py/compare/v1.20.1...v1.20.2
 [1.20.3]: https://github.com/scanoss/scanoss.py/compare/v1.20.2...v1.20.3
 [1.20.4]: https://github.com/scanoss/scanoss.py/compare/v1.20.3...v1.20.4
+[1.20.5]: https://github.com/scanoss/scanoss.py/compare/v1.20.4...v1.20.5

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.20.4'
+__version__ = '1.20.5'

--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -31,6 +31,7 @@ import re
 import sys
 
 import importlib_resources
+from packageurl import PackageURL
 
 from . import __version__
 
@@ -242,6 +243,9 @@ class SpdxLite:
 
         for license_info in licenses:
             name = license_info.get('name')
+            source = license_info.get('source')
+            if source not in ("component_declared", "license_file", "file_header"):
+                continue
             if name and name not in seen_names:
                 processed_licenses.append({'id': name})
                 seen_names.add(name)
@@ -429,7 +433,7 @@ class SpdxLite:
             'externalRefs': [
                 {
                     'referenceCategory': 'PACKAGE-MANAGER',
-                    'referenceLocator': purl_ver,
+                    'referenceLocator': PackageURL.from_string(purl_ver).to_string(),
                     'referenceType': 'purl'
                 }
             ],
@@ -465,9 +469,7 @@ class SpdxLite:
         lic_set = set()
         for lic in licenses:
             lc_id = lic.get('id')
-            source = lic.get('source')
-            if lc_id and source in ("component_declared", "license_file"):
-                self._process_license_id(lc_id, lic_refs, lic_set)
+            self._process_license_id(lc_id, lic_refs, lic_set)
 
         return self._format_license_text(lic_set)
 
@@ -667,8 +669,6 @@ class SpdxLite:
                             self._spdx_licenses[lic_id_short] = lic_id
                     if lic_name:
                         self._spdx_lic_names[lic_name] = lic_id
-            # self.print_stderr(f'Licenses: {self._spdx_licenses}')
-            # self.print_stderr(f'Lookup: {self._spdx_lic_lookup}')
         return True
 
     def get_spdx_license_id(self, lic_name: str) -> str:

--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -466,7 +466,7 @@ class SpdxLite:
         for lic in licenses:
             lc_id = lic.get('id')
             source = lic.get('source')
-            if lc_id and (source == "component_declared" or source == "license_file"):
+            if lc_id and source in ("component_declared", "license_file"):
                 self._process_license_id(lc_id, lic_refs, lic_set)
 
         return self._format_license_text(lic_set)

--- a/src/scanoss/spdxlite.py
+++ b/src/scanoss/spdxlite.py
@@ -285,7 +285,8 @@ class SpdxLite:
         lic_set = set()
         for lic in licenses:
             lc_id = lic.get('id')
-            if lc_id:
+            source = lic.get('source')
+            if lc_id and (source == "component_declared" or source == "license_file"):
                 self._process_license_id(lc_id, lic_refs, lic_set)
 
         return self._format_license_text(lic_set)


### PR DESCRIPTION
### **What**

- Fixes bug on SPDXLite output format. See related bugs [Invalid SPDX: incorrect license exception](https://github.com/scanoss/scanoss.py/issues/62)  and [Incorrect license_id](https://github.com/scanoss/scanoss.py/issues/100)

SPDXLite output is valid for Telco Validator and  spdx tool java: https://github.com/spdx/tools-java

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the software version to 1.20.5 with a refreshed changelog.
- **New Features**
  - Introduced a new validation check that enhances the reliability of license outputs.
- **Documentation**
  - Improved descriptions and explanations related to licensing details for clearer guidance.
  - Added a new version entry in the changelog for version 1.20.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->