### PR TITLE
fix: resolve #106 by avoiding shared mutable queues in ThreadedScanning

### DIFF
--- a/src/scanoss/threadedscanning.py
+++ b/src/scanoss/threadedscanning.py
@@ -23,13 +23,13 @@ SPDX-License-Identifier: MIT
 """
 
 import os
+import queue
 import sys
 import threading
-import queue
 import time
-
-from typing import Dict, List
 from dataclasses import dataclass
+from typing import Dict, List
+
 from progress.bar import Bar
 
 from .scanossapi import ScanossApi
@@ -134,7 +134,7 @@ class ThreadedScanning(ScanossBase):
         :param wfp: WFP to add to queue
         """
         if wfp is None or wfp == '':
-            self.print_stderr(f'Warning: empty WFP. Skipping from scan...')
+            self.print_stderr('Warning: empty WFP. Skipping from scan...')
         else:
             self.inputs.put(wfp)
 

--- a/src/scanoss/threadedscanning.py
+++ b/src/scanoss/threadedscanning.py
@@ -49,8 +49,6 @@ class ThreadedScanning(ScanossBase):
     Multiple threads pull messages off this queue, process the request and put the results into an output queue
     """
 
-    inputs: queue.Queue = queue.Queue()
-    output: queue.Queue = queue.Queue()
     bar: Bar = None
 
     def __init__(
@@ -65,6 +63,8 @@ class ThreadedScanning(ScanossBase):
         :param nb_threads: Number of thread to run (default 5)
         """
         super().__init__(debug, trace, quiet)
+        self.inputs = queue.Queue()
+        self.output = queue.Queue()
         self.scanapi = scanapi
         self.nb_threads = nb_threads
         self._isatty = sys.stderr.isatty()


### PR DESCRIPTION
Move input/output queues into __init__ to ensure instance-level isolation. Did not use `field(default_factory=...)` because __init__ is explicitly defined, which disables dataclass auto-init behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the scanning operations by updating the initialization process. Each scanning instance now manages its own operational state independently, promoting improved stability and more reliable performance.
	- Streamlined warning message format for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->