### PR TITLE
Add `grpc-ssl-target` option to CLI to override SSL target name for gRPC connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.25.0] - 2025-06-04
+### Added
+- Add `grpc-ssl-target` option to CLI to override SSL target name for gRPC connections
+
 ## [1.24.0] - 2025-05-28
 ### Added
 - Add `crypto` subcommand to retrieve cryptographic algorithms for the given components
@@ -523,3 +527,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.22.0]: https://github.com/scanoss/scanoss.py/compare/v1.21.0...v1.22.0
 [1.23.0]: https://github.com/scanoss/scanoss.py/compare/v1.22.0...v1.23.0
 [1.24.0]: https://github.com/scanoss/scanoss.py/compare/v1.23.0...v1.24.0
+[1.25.0]: https://github.com/scanoss/scanoss.py/compare/v1.24.0...v1.25.0

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.24.0'
+__version__ = '1.25.0'

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -761,6 +761,12 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
             '"REQUESTS_CA_BUNDLE=/path/to/cacert.pem" and '
             '"GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=/path/to/cacert.pem" for gRPC',
         )
+        p.add_argument(
+            '--grpc-ssl-target',
+            type=str,
+            help='Override SSL target name for gRPC connections (optional). '
+            'Useful when connecting to localhost with a certificate issued for a different domain.',
+        )
 
     # Global GRPC options
     for p in [
@@ -1138,6 +1144,7 @@ def scan(parser, args):  # noqa: PLR0912, PLR0915
         ignore_cert_errors=args.ignore_cert_errors,
         proxy=args.proxy,
         grpc_proxy=args.grpc_proxy,
+        grpc_ssl_target=args.grpc_ssl_target,
         pac=pac_file,
         ca_cert=args.ca_cert,
         retry=args.retry,
@@ -1617,6 +1624,7 @@ def comp_vulns(parser, args):
         ca_cert=args.ca_cert,
         proxy=args.proxy,
         grpc_proxy=args.grpc_proxy,
+        grpc_ssl_target=args.grpc_ssl_target,
         pac=pac_file,
         timeout=args.timeout,
         req_headers=process_req_headers(args.header),
@@ -1652,6 +1660,7 @@ def comp_semgrep(parser, args):
         ca_cert=args.ca_cert,
         proxy=args.proxy,
         grpc_proxy=args.grpc_proxy,
+        grpc_ssl_target=args.grpc_ssl_target,
         pac=pac_file,
         timeout=args.timeout,
         req_headers=process_req_headers(args.header),
@@ -1690,6 +1699,7 @@ def comp_search(parser, args):
         ca_cert=args.ca_cert,
         proxy=args.proxy,
         grpc_proxy=args.grpc_proxy,
+        grpc_ssl_target=args.grpc_ssl_target,
         pac=pac_file,
         timeout=args.timeout,
         req_headers=process_req_headers(args.header),
@@ -1735,6 +1745,7 @@ def comp_versions(parser, args):
         ca_cert=args.ca_cert,
         proxy=args.proxy,
         grpc_proxy=args.grpc_proxy,
+        grpc_ssl_target=args.grpc_ssl_target,
         pac=pac_file,
         timeout=args.timeout,
         req_headers=process_req_headers(args.header),
@@ -1770,6 +1781,7 @@ def comp_provenance(parser, args):
         ca_cert=args.ca_cert,
         proxy=args.proxy,
         grpc_proxy=args.grpc_proxy,
+        grpc_ssl_target=args.grpc_ssl_target,
         pac=pac_file,
         timeout=args.timeout,
         req_headers=process_req_headers(args.header),

--- a/src/scanoss/components.py
+++ b/src/scanoss/components.py
@@ -50,6 +50,7 @@ class Components(ScanossBase):
         proxy: str = None,
         grpc_proxy: str = None,
         ca_cert: str = None,
+        grpc_ssl_target: str = None,
         pac: PACFile = None,
         req_headers: dict = None,
     ):
@@ -77,6 +78,7 @@ class Components(ScanossBase):
             api_key=api_key,
             ver_details=ver_details,
             ca_cert=ca_cert,
+            grpc_ssl_target=grpc_ssl_target,
             proxy=proxy,
             pac=pac,
             grpc_proxy=grpc_proxy,

--- a/src/scanoss/scanners/container_scanner.py
+++ b/src/scanoss/scanners/container_scanner.py
@@ -228,6 +228,7 @@ class ContainerScanner:
             url=config.apiurl,
             api_key=config.key,
             ca_cert=config.ca_cert,
+            grpc_ssl_target=config.grpc_ssl_target,
             proxy=config.proxy,
             pac=config.pac,
             grpc_proxy=config.grpc_proxy,

--- a/src/scanoss/scanners/scanner_config.py
+++ b/src/scanoss/scanners/scanner_config.py
@@ -51,6 +51,7 @@ class ScannerConfig:
     grpc_proxy: Optional[str] = None
 
     ca_cert: Optional[str] = None
+    grpc_ssl_target: Optional[str] = None
     pac: Optional[PACFile] = None
 
 
@@ -69,5 +70,6 @@ def create_scanner_config_from_args(args) -> ScannerConfig:
         proxy=getattr(args, 'proxy', None),
         grpc_proxy=getattr(args, 'grpc_proxy', None),
         ca_cert=getattr(args, 'ca_cert', None),
+        grpc_ssl_target=getattr(args, 'grpc_ssl_target', None),
         pac=getattr(args, 'pac', None),
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new CLI option to override the SSL target name for gRPC connections, improving flexibility when connecting to servers with mismatched certificates.

- **Documentation**
  - Updated the changelog to include details for version 1.25.0 and document the new CLI option.

- **Style**
  - Improved code formatting and organization for better readability (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->