### PR TITLE
fix(crypto): dict object error in --input processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.28.1] - 2025-07-10
+### Added
+- Fix purls parsing on `crypto` subcommand
+
 ## [1.28.0] - 2025-07-10
 ### Added
 - Add vulnerabilities response to `folder-scan` CycloneDX output
@@ -587,3 +591,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.26.3]: https://github.com/scanoss/scanoss.py/compare/v1.26.2...v1.26.3
 [1.27.0]: https://github.com/scanoss/scanoss.py/compare/v1.26.3...v1.27.0
 [1.27.1]: https://github.com/scanoss/scanoss.py/compare/v1.27.0...v1.27.1
+[1.28.0]: https://github.com/scanoss/scanoss.py/compare/v1.27.1...v1.28.0
+[1.28.1]: https://github.com/scanoss/scanoss.py/compare/v1.28.0...v1.28.1

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.28.0'
+__version__ = '1.28.1'

--- a/src/scanoss/cryptography.py
+++ b/src/scanoss/cryptography.py
@@ -53,16 +53,16 @@ class CryptographyConfig:
                 raise ScanossCryptographyError('The supplied input file is not in the correct PurlRequest format.')
             purls = input_file_validation.data['purls']
             purls_with_requirement = []
-            if self.with_range:
-                if any('requirement' not in p for p in purls):
-                    raise ScanossCryptographyError(
-                        f'One or more PURLs in "{self.input_file}" are missing the "requirement" field.'
-                    )
+            if self.with_range and any('requirement' not in p for p in purls):
+                raise ScanossCryptographyError(
+                    f'One or more PURLs in "{self.input_file}" are missing the "requirement" field.'
+                )
+
+            for purl in purls:
+                if 'requirement' in purl:
+                    purls_with_requirement.append(f'{purl["purl"]}@{purl["requirement"]}')
                 else:
-                    for purl in purls:
-                        purls_with_requirement.append(f'{purl["purl"]}@{purl["requirement"]}')
-            else:
-                purls_with_requirement = [purl["purl"] for purl in purls]
+                    purls_with_requirement.append(purl['purl'])
             self.purl = purls_with_requirement
 
 
@@ -198,12 +198,26 @@ class Cryptography:
         return {
             'purls': [
                 {
-                    'purl': p,
-                    'requirement': self._extract_version_from_purl(p),
+                    'purl': self._remove_version_from_purl(purl),
+                    'requirement': self._extract_version_from_purl(purl),
                 }
-                for p in self.config.purl
+                for purl in self.config.purl
             ]
         }
+
+    def _remove_version_from_purl(self, purl: str) -> str:
+        """
+        Remove version from purl
+
+        Args:
+            purl (str): The purl string to remove the version from
+
+        Returns:
+            str: The purl string without the version
+        """
+        if '@' not in purl:
+            return purl
+        return purl.split('@')[0]
 
     def _extract_version_from_purl(self, purl: str) -> str:
         """

--- a/src/scanoss/cryptography.py
+++ b/src/scanoss/cryptography.py
@@ -62,7 +62,7 @@ class CryptographyConfig:
                     for purl in purls:
                         purls_with_requirement.append(f'{purl["purl"]}@{purl["requirement"]}')
             else:
-                purls_with_requirement = purls
+                purls_with_requirement = [purl["purl"] for purl in purls]
             self.purl = purls_with_requirement
 
 


### PR DESCRIPTION
This PR fixes a bug in the crypto command when using --input with JSON files.

###  Problem:
When running `scanoss-py crypto algorithms --key $SC_KEY --input purls.json`, users were getting the error:
```
 'dict' object has no attribute 'split'. 
```

###  Testing:
  After this fix, the crypto command works correctly with JSON input files like:
```json
{
  "purls": [
    {"purl": "pkg:github/scanoss/engine@1.0.0"}
  ]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of package URLs (PURLs) in the cryptography-related command to ensure correct handling of version requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->