### PR TITLE
[SP-2912] fix: cdx format error when license id is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.28.2] - 2025-07-14
+### Fixed
+- Fix CycloneDX format when license id is None
+
 ## [1.28.1] - 2025-07-10
 ### Added
 - Fix purls parsing on `crypto` subcommand
@@ -593,3 +597,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.27.1]: https://github.com/scanoss/scanoss.py/compare/v1.27.0...v1.27.1
 [1.28.0]: https://github.com/scanoss/scanoss.py/compare/v1.27.1...v1.28.0
 [1.28.1]: https://github.com/scanoss/scanoss.py/compare/v1.28.0...v1.28.1
+[1.28.2]: https://github.com/scanoss/scanoss.py/compare/v1.28.1...v1.28.2

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.28.1'
+__version__ = '1.28.2'

--- a/src/scanoss/cyclonedx.py
+++ b/src/scanoss/cyclonedx.py
@@ -219,6 +219,8 @@ class CycloneDx(ScanossBase):
                 lic_set = set()
                 for lic in licenses:  # Get a unique set of licenses
                     lc_id = lic.get('id')
+                    if not lc_id:
+                        continue
                     spdx_id = self._spdx.get_spdx_license_id(lc_id)
                     lic_set.add(spdx_id if spdx_id else lc_id)
                 for lc_id in lic_set:  # Store licenses for later inclusion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license processing to prevent errors from invalid or missing license IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->