### PR TITLE
[SP-3346] feat: use gRPC by default instead of REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.35.0] - 2025-10-07
+### Modified
+- Use gRPC instead of REST for API calls
+
 ## [1.34.0] - 2025-10-06
 ### Added
 - Add REST API support for decoration commands

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.34.0'
+__version__ = '1.35.0'

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -1070,7 +1070,8 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
         c_versions,
         c_licenses,
     ]:
-        p.add_argument('--grpc', action='store_true', help='Enable gRPC support')
+        p.add_argument('--grpc', action='store_true', default=True, help='Use gRPC (default)')
+        p.add_argument('--rest', action='store_true', dest='rest', help='Use REST instead of gRPC')
 
     # Help/Trace command options
     for p in [
@@ -1111,6 +1112,12 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
         p.add_argument('--quiet', '-q', action='store_true', help='Enable quiet mode')
 
     args = parser.parse_args()
+
+    # TODO: Remove this hack once we go back to using REST as default
+    # Handle --rest overriding --grpc default
+    if hasattr(args, 'rest') and args.rest:
+        args.grpc = False
+
     if args.version:
         ver(parser, args)
         sys.exit(0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default API transport is now gRPC across CLI subcommands.
  - Added --rest flag to explicitly use REST; selecting it disables gRPC.
  - The --grpc option is enabled by default unless --rest is specified.

- Documentation
  - Updated changelog with version 1.35.0 and note on switching API calls to gRPC.

- Chores
  - Bumped version to 1.35.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->