### PR TITLE
[SP-3572] feat: add support for SCANOSS_DEBUG env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [1.38.0] - 2025-10-24
+### Added
+- Add support for settings debug mode via `SCANOSS_DEBUG` environment variable
+
 ## [1.37.1] - 2025-10-21
 ### Added
 - Added source filtering to cyclonedx conversion
@@ -696,3 +700,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.36.0]: https://github.com/scanoss/scanoss.py/compare/v1.35.0...v1.36.0
 [1.37.0]: https://github.com/scanoss/scanoss.py/compare/v1.36.0...v1.37.0
 [1.37.1]: https://github.com/scanoss/scanoss.py/compare/v1.37.0...v1.37.1
+[1.38.0]: https://github.com/scanoss/scanoss.py/compare/v1.37.1...v1.38.0

--- a/CLIENT_HELP.md
+++ b/CLIENT_HELP.md
@@ -130,6 +130,28 @@ pip3 install --upgrade https://github.com/pietrodn/grpcio-mac-arm-build/releases
 
 This command above will install `grpcio` `1.5.1` for Python `3.9`. To install for `3.10` simply replace the `cp39` with `cp310`.
 
+## Debug Mode
+The SCANOSS CLI supports debug mode to provide additional diagnostic information during command execution. This is useful for troubleshooting issues or understanding the internal operations of the CLI.
+
+There are two ways to enable debug mode:
+
+### Debug Mode via Environment Variable
+Set the `SCANOSS_DEBUG` environment variable to `true`:
+```bash
+export SCANOSS_DEBUG=true
+scanoss-py scan -o results.json src
+```
+
+This method is particularly useful when you want debug output enabled for multiple consecutive commands without having to add the flag each time.
+
+### Debug Mode via Command Line Flag
+Use the `-d` or `--debug` flag with any command:
+```bash
+scanoss-py scan -d -o results.json src
+```
+
+**Note:** The command line flag will override the environment variable setting if both are present.
+
 ## Command Execution
 There are multiple commands (and sub commands) available through `scanoss-py`.
 Detailed help is available for all directly from the CLI itself:

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.37.1'
+__version__ = '1.38.0'

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -929,10 +929,7 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
     )
 
     delta_sub = p_delta.add_subparsers(
-        title='Delta Commands',
-        dest='subparsercmd',
-        description='Delta sub-commands',
-        help='Delta sub-commands'
+        title='Delta Commands', dest='subparsercmd', description='Delta sub-commands', help='Delta sub-commands'
     )
 
     # Delta Sub-command: copy
@@ -1165,9 +1162,15 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
         p_crypto_versions_in_range,
         c_licenses,
         e_dt,
-        p_copy
+        p_copy,
     ]:
-        p.add_argument('--debug', '-d', action='store_true', help='Enable debug messages')
+        p.add_argument(
+            '--debug',
+            '-d',
+            action='store_true',
+            default=os.environ.get('SCANOSS_DEBUG', '').lower() == 'true',
+            help='Enable debug messages (can also be set via environment variable SCANOSS_DEBUG)',
+        )
         p.add_argument('--trace', '-t', action='store_true', help='Enable trace messages, including API posts')
         p.add_argument('--quiet', '-q', action='store_true', help='Enable quiet mode')
 
@@ -1186,8 +1189,21 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
         sys.exit(1)
     elif (
         args.subparser
-        in ('utils', 'ut', 'component', 'comp', 'inspect', 'insp', 'ins',
-            'crypto', 'cr', 'export', 'exp', 'delta', 'dl')
+        in (
+            'utils',
+            'ut',
+            'component',
+            'comp',
+            'inspect',
+            'insp',
+            'ins',
+            'crypto',
+            'cr',
+            'export',
+            'exp',
+            'delta',
+            'dl',
+        )
     ) and not args.subparsercmd:
         parser.parse_args([args.subparser, '--help'])  # Force utils helps to be displayed
         sys.exit(1)
@@ -2634,6 +2650,7 @@ def initialise_empty_file(filename: str):
             print_stderr(f'Error: Unable to create output file {filename}: {e}')
             sys.exit(1)
 
+
 def delta_copy(parser, args):
     """
     Handle delta copy command.
@@ -2661,8 +2678,15 @@ def delta_copy(parser, args):
         initialise_empty_file(args.output)
     try:
         # Create and configure delta copy command
-        delta = Delta(debug=args.debug, trace=args.trace, quiet=args.quiet, filepath=args.input, folder=args.folder,
-                      output=args.output, root_dir=args.root)
+        delta = Delta(
+            debug=args.debug,
+            trace=args.trace,
+            quiet=args.quiet,
+            filepath=args.input,
+            folder=args.folder,
+            output=args.output,
+            root_dir=args.root,
+        )
         # Execute copy and exit with appropriate status code
         status, _ = delta.copy()
         sys.exit(status)
@@ -2671,6 +2695,7 @@ def delta_copy(parser, args):
         if args.debug:
             traceback.print_exc()
         sys.exit(1)
+
 
 def main():
     """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug mode support via SCANOSS_DEBUG environment variable and -d/--debug CLI flag. The CLI flag overrides the environment variable when both are present.

* **Documentation**
  * Added Debug Mode documentation with usage examples for both activation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->