### PR TITLE
SP-3649-update-copyleft-inspection-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Added `--license-sources` (`-ls`) option to copyleft inspection
+  - Filter which license sources to check (component_declared, license_file, file_header, file_spdx_tag, scancode)
+  - Supports both `-ls source1 source2` and `-ls source1 -ls source2` syntax
+
+### Changed
+- Copyleft inspection now defaults to component-level licenses only (component_declared, license_file)
+  - Reduces noise from file-level license detections (file_header, scancode)
+  - Use `-ls` to override and check specific sources
+
 ### Fixed
 - Fixed terminal cursor disappearing after aborting scan with Ctrl+C
 

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -55,6 +55,7 @@ from . import __version__
 from .components import Components
 from .constants import (
     DEFAULT_API_TIMEOUT,
+    DEFAULT_COPYLEFT_LICENSE_SOURCES,
     DEFAULT_HFH_DEPTH,
     DEFAULT_HFH_MIN_ACCEPTED_SCORE,
     DEFAULT_HFH_RANK_THRESHOLD,
@@ -64,6 +65,7 @@ from .constants import (
     DEFAULT_TIMEOUT,
     MIN_TIMEOUT,
     PYTHON_MAJOR_VERSION,
+    VALID_LICENSE_SOURCES,
 )
 from .csvoutput import CsvOutput
 from .cyclonedx import CycloneDx
@@ -698,6 +700,19 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
         p.add_argument('--include', help='Additional licenses to include in analysis (comma-separated list)')
         p.add_argument('--exclude', help='Licenses to exclude from analysis (comma-separated list)')
         p.add_argument('--explicit', help='Use only these specific licenses for analysis (comma-separated list)')
+
+    # License source filtering
+    # NOTE: Python <3.13 shows choices for each option form (noisy), Python 3.13+ shows once (clean)
+    # See: https://github.com/python/cpython/commit/c4a2e8a2c5188c3288d57b80852e92c83f46f6f3
+    for p in [p_inspect_raw_copyleft, p_inspect_legacy_copyleft]:
+        p.add_argument(
+            '-ls', '--license-sources',
+            action='extend',
+            nargs='+',
+            choices=VALID_LICENSE_SOURCES,
+            help=f'Specify which license sources to check for copyleft violations. Each license object in scan results '
+                 f'has a source field indicating its origin. Default: {", ".join(DEFAULT_COPYLEFT_LICENSE_SOURCES)}',
+        )
 
     # Common options for (legacy) copyleft and undeclared component inspection
     for p in [p_inspect_raw_copyleft, p_inspect_raw_undeclared, p_inspect_legacy_copyleft, p_inspect_legacy_undeclared]:
@@ -1752,6 +1767,7 @@ def inspect_copyleft(parser, args):
             include=args.include,  # Additional licenses to check
             exclude=args.exclude,  # Licenses to ignore
             explicit=args.explicit,  # Explicit license list
+            license_sources=args.license_sources,  # License sources to check (list)
         )
         # Execute inspection and exit with appropriate status code
         status, _ = i_copyleft.run()

--- a/src/scanoss/constants.py
+++ b/src/scanoss/constants.py
@@ -17,3 +17,6 @@ DEFAULT_HFH_RANK_THRESHOLD = 5
 DEFAULT_HFH_DEPTH = 1
 DEFAULT_HFH_RECURSIVE_THRESHOLD = 0.8
 DEFAULT_HFH_MIN_ACCEPTED_SCORE = 0.15
+
+VALID_LICENSE_SOURCES = ['component_declared', 'license_file', 'file_header', 'file_spdx_tag', 'scancode']
+DEFAULT_COPYLEFT_LICENSE_SOURCES = ['component_declared', 'license_file']

--- a/src/scanoss/inspection/policy_check/scanoss/copyleft.py
+++ b/src/scanoss/inspection/policy_check/scanoss/copyleft.py
@@ -26,6 +26,8 @@ import json
 from dataclasses import dataclass
 from typing import Dict, List
 
+from scanoss.constants import DEFAULT_COPYLEFT_LICENSE_SOURCES
+
 from ...policy_check.policy_check import PolicyCheck, PolicyOutput, PolicyStatus
 from ...utils.markdown_utils import generate_jira_table, generate_table
 from ...utils.scan_result_processor import ScanResultProcessor
@@ -63,6 +65,7 @@ class Copyleft(PolicyCheck[Component]):
         include: str = None,
         exclude: str = None,
         explicit: str = None,
+        license_sources: list = None,
     ):
         """
         Initialise the Copyleft class.
@@ -77,6 +80,7 @@ class Copyleft(PolicyCheck[Component]):
         :param include: Licenses to include in the analysis
         :param exclude: Licenses to exclude from the analysis
         :param explicit: Explicitly defined licenses
+        :param license_sources: List of license sources to check
         """
         super().__init__(
             debug, trace, quiet, format_type, status, name='Copyleft Policy', output=output
@@ -85,6 +89,7 @@ class Copyleft(PolicyCheck[Component]):
         self.filepath = filepath
         self.output = output
         self.status = status
+        self.license_sources = license_sources or DEFAULT_COPYLEFT_LICENSE_SOURCES
         self.results_processor = ScanResultProcessor(
             self.debug,
             self.trace,
@@ -92,7 +97,8 @@ class Copyleft(PolicyCheck[Component]):
             self.filepath,
             include,
             exclude,
-            explicit)
+            explicit,
+            self.license_sources)
 
     def _json(self, components: list[Component]) -> PolicyOutput:
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --license-sources / -ls option to select which license detection sources are considered during copyleft inspections; defaults now favor component-level sources (reducing file-level noise).
  * Inspection output respects the selected sources when reporting licenses.

* **Tests**
  * Expanded test coverage for license source filtering: defaults, single/multiple sources, include/exclude filters, various outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->