### PR TITLE
chore(cli): deprecate --no-wfp-output flag for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Upcoming changes...
 
+## [1.43.1] - 2026-01-05
+### Changed
+- Restored `--no-wfp-output` flag for backwards compatibility (deprecated, no effect)
+
 ## [1.43.0] - 2026-01-02
 ### Changed
-  - Scan command no longer generates `scanner_output.wfp` file
-  - Removed `--no-wfp-output` flag (no longer needed)
+- Scan command no longer generates `scanner_output.wfp` file
+- Removed `--no-wfp-output` flag (no longer needed)
 
 ## [1.42.0] - 2025-12-17
 ### Added
@@ -768,3 +772,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.41.1]: https://github.com/scanoss/scanoss.py/compare/v1.41.0...v1.41.1
 [1.42.0]: https://github.com/scanoss/scanoss.py/compare/v1.41.1...v1.42.0
 [1.43.0]: https://github.com/scanoss/scanoss.py/compare/v1.42.0...v1.43.0
+[1.43.1]: https://github.com/scanoss/scanoss.py/compare/v1.43.0...v1.43.1

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.43.0'
+__version__ = '1.43.1'

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -186,6 +186,10 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
     )
     p_scan.add_argument('--dep-scope-inc', '-dsi', type=str, help='Include dependencies with declared scopes')
     p_scan.add_argument('--dep-scope-exc', '-dse', type=str, help='Exclude dependencies with declared scopes')
+    p_scan.add_argument(
+        '--no-wfp-output', action='store_true',
+        help='DEPRECATED: Scans no longer generate scanner_output.wfp. Use "fingerprint -o" to create WFP files.'
+    )
 
     # Sub-command: fingerprint
     p_wfp = subparsers.add_parser(
@@ -1470,6 +1474,8 @@ def scan(parser, args):  # noqa: PLR0912, PLR0915
         )
         parser.parse_args([args.subparser, '-h'])
         sys.exit(1)
+    if args.no_wfp_output:
+        print_stderr('Warning: --no-wfp-output is deprecated and has no effect. It will be removed in a future version')
     if args.pac and args.proxy:
         print_stderr('Please specify one of --proxy or --pac, not both')
         parser.parse_args([args.subparser, '-h'])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release to 1.43.1 and adjusted release notes/links for clarity.
  * Restored the deprecated --no-wfp-output command-line flag; it has no functional effect and now emits a deprecation warning when used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->