### PR TITLE
Fix default ranking_threshold value in scanoss-settings-schema.json

### DIFF
--- a/src/scanoss/data/scanoss-settings-schema.json
+++ b/src/scanoss/data/scanoss-settings-schema.json
@@ -177,7 +177,7 @@
               "type": ["integer", "null"],
               "description": "Ranking threshold value. A value of -1 defers to server configuration",
               "minimum": -1,
-              "maximum": 99,
+              "maximum": 10,
               "default": 0
             },
             "min_snippet_hits": {
@@ -345,4 +345,3 @@
     }
   }
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the maximum ranking threshold setting to optimize file snippet ranking behavior during system processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->