### PR TITLE
fix(postprocessor): ensure `license` field in BOM replace rules is applied correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.50.1] - 2026-03-23
 ### Fixed
 - Fixed `bom.replace` rules with a `license` field: the license is now applied to the replaced result instead of being silently dropped
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed `bom.replace` rules with a `license` field: the license is now applied to the replaced result instead of being silently dropped
 
 ## [1.50.0] - 2026-03-17
 ### Fixed

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.50.0'
+__version__ = '1.50.1'

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -184,14 +184,19 @@ class ScanPostProcessor(ScanossBase):
                 )
                 return result
 
-            # Pop all stale component-level fields first
-            for key in COMPONENT_LEVEL_FIELDS:
-                result.pop(key, None)
-
-            # Pop stale KB match fields (remote file info)
-            result.pop('file', None)
-            result.pop('file_hash', None)
-            result.pop('file_url', None)
+            # Reset component-level fields to defaults
+            result['licenses'] = []
+            result['cryptography'] = []
+            result['dependencies'] = []
+            result['quality'] = []
+            result['vulnerabilities'] = []
+            result['health'] = {}
+            result['provenance'] = ''
+            result['latest'] = ''
+            result['release_date'] = ''
+            result['version'] = ''
+            result['url_hash'] = ''
+            result['url_stats'] = {}
 
             # Set what we know from the PURL
             result['component'] = new_component.get('name')
@@ -202,7 +207,7 @@ class ScanPostProcessor(ScanossBase):
         if replace_rule.license:
             result['licenses'] = [{'name': replace_rule.license}]
         elif not self.component_info_map.get(replace_rule.replace_with):
-            result.pop('licenses', None)
+            result['licenses'] = []
 
         result['purl'] = [replace_rule.replace_with]
         result['status'] = 'identified'

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -30,6 +30,13 @@ from packageurl.contrib import purl2url
 from .scanoss_settings import BomEntry, ReplaceRule, ScanossSettings, find_best_match
 from .scanossbase import ScanossBase
 
+COMPONENT_LEVEL_FIELDS = (
+    'component', 'vendor', 'url', 'url_hash', 'version', 'latest',
+    'release_date', 'licenses', 'url_stats', 'cryptography',
+    'vulnerabilities', 'provenance', 'dependencies', 'health',
+    'quality',
+)
+
 
 def _get_match_type_message(result_path: str, bom_entry: BomEntry, action: str) -> str:
     """
@@ -163,10 +170,7 @@ class ScanPostProcessor(ScanossBase):
             # Only copy component-level fields from the map entry, leaving
             # per-file fields (file, file_hash, lines, matched, etc.) untouched.
             source = self.component_info_map[replace_rule.replace_with]
-            for key in ('component', 'vendor', 'url', 'url_hash', 'version', 'latest',
-                        'release_date', 'licenses', 'url_stats', 'cryptography',
-                        'vulnerabilities', 'provenance', 'dependencies', 'health',
-                        'quality'):
+            for key in COMPONENT_LEVEL_FIELDS:
                 if key in source:
                     result[key] = source[key]
         else:
@@ -180,19 +184,20 @@ class ScanPostProcessor(ScanossBase):
                 )
                 return result
 
+            # Pop all stale component-level fields first
+            for key in COMPONENT_LEVEL_FIELDS:
+                result.pop(key, None)
+
+            # Pop stale KB match fields (remote file info)
+            result.pop('file', None)
+            result.pop('file_hash', None)
+            result.pop('file_url', None)
+
+            # Set what we know from the PURL
             result['component'] = new_component.get('name')
             result['url'] = new_component_url
             result['vendor'] = new_component.get('namespace')
 
-            result.pop('file', None)
-            result.pop('file_hash', None)
-            result.pop('file_url', None)
-            result.pop('latest', None)
-            result.pop('release_date', None)
-            result.pop('source_hash', None)
-            result.pop('url_hash', None)
-            result.pop('url_stats', None)
-            result.pop('version', None)
 
         if replace_rule.license:
             result['licenses'] = [{'name': replace_rule.license}]

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -170,7 +170,7 @@ class ScanPostProcessor(ScanossBase):
             try:
                 new_component = PackageURL.from_string(replace_rule.replace_with).to_dict()
                 new_component_url = purl2url.get_repo_url(replace_rule.replace_with)
-            except RuntimeError:
+            except (ValueError, RuntimeError):
                 self.print_stderr(
                     f"ERROR: Issue while replacing: Invalid PURL '{replace_rule.replace_with}'"
                     ' in settings file. Skipping.'

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -160,12 +160,13 @@ class ScanPostProcessor(ScanossBase):
             dict: Updated result
         """
         if self.component_info_map.get(replace_rule.replace_with):
-            # Preserve per-file fields that are specific to the scanned file
-            per_file_keys = ('file', 'file_hash', 'file_url', 'source_hash', 'url_hash',
-                             'lines', 'oss_lines', 'matched')
-            preserved = {k: result[k] for k in per_file_keys if k in result}
-            result.update(self.component_info_map[replace_rule.replace_with])
-            result.update(preserved)
+            # Only copy component-level fields from the map entry, leaving
+            # per-file fields (file, file_hash, lines, matched, etc.) untouched.
+            source = self.component_info_map[replace_rule.replace_with]
+            for key in ('component', 'vendor', 'url', 'version', 'latest',
+                        'release_date', 'licenses', 'url_stats'):
+                if key in source:
+                    result[key] = source[key]
         else:
             try:
                 new_component = PackageURL.from_string(replace_rule.replace_with).to_dict()

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -163,8 +163,10 @@ class ScanPostProcessor(ScanossBase):
             # Only copy component-level fields from the map entry, leaving
             # per-file fields (file, file_hash, lines, matched, etc.) untouched.
             source = self.component_info_map[replace_rule.replace_with]
-            for key in ('component', 'vendor', 'url', 'version', 'latest',
-                        'release_date', 'licenses', 'url_stats'):
+            for key in ('component', 'vendor', 'url', 'url_hash', 'version', 'latest',
+                        'release_date', 'licenses', 'url_stats', 'cryptography',
+                        'vulnerabilities', 'provenance', 'dependencies', 'health',
+                        'quality'):
                 if key in source:
                     result[key] = source[key]
         else:

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -160,7 +160,12 @@ class ScanPostProcessor(ScanossBase):
             dict: Updated result
         """
         if self.component_info_map.get(replace_rule.replace_with):
+            # Preserve per-file fields that are specific to the scanned file
+            per_file_keys = ('file', 'file_hash', 'file_url', 'source_hash', 'url_hash',
+                             'lines', 'oss_lines', 'matched')
+            preserved = {k: result[k] for k in per_file_keys if k in result}
             result.update(self.component_info_map[replace_rule.replace_with])
+            result.update(preserved)
         else:
             try:
                 new_component = PackageURL.from_string(replace_rule.replace_with).to_dict()
@@ -176,9 +181,6 @@ class ScanPostProcessor(ScanossBase):
             result['url'] = new_component_url
             result['vendor'] = new_component.get('namespace')
 
-            result.pop('licenses', None)
-            if replace_rule.license:
-                result['licenses'] = [{'name': replace_rule.license}]
             result.pop('file', None)
             result.pop('file_hash', None)
             result.pop('file_url', None)
@@ -187,8 +189,12 @@ class ScanPostProcessor(ScanossBase):
             result.pop('source_hash', None)
             result.pop('url_hash', None)
             result.pop('url_stats', None)
-            result.pop('url_stats', None)
             result.pop('version', None)
+
+        if replace_rule.license:
+            result['licenses'] = [{'name': replace_rule.license}]
+        elif not self.component_info_map.get(replace_rule.replace_with):
+            result.pop('licenses', None)
 
         result['purl'] = [replace_rule.replace_with]
         result['status'] = 'identified'

--- a/src/scanoss/scanpostprocessor.py
+++ b/src/scanoss/scanpostprocessor.py
@@ -22,7 +22,7 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-from typing import List, Tuple
+from typing import List, Optional
 
 from packageurl import PackageURL
 from packageurl.contrib import purl2url
@@ -117,7 +117,7 @@ class ScanPostProcessor(ScanossBase):
             )
             return self.results
         self._remove_dismissed_files()
-        self._replace_purls()
+        self._apply_replace_rules()
         return self.results
 
     def _remove_dismissed_files(self):
@@ -133,9 +133,9 @@ class ScanPostProcessor(ScanossBase):
             if not self._should_remove_result(result_path, result, to_remove_entries)
         }
 
-    def _replace_purls(self):
+    def _apply_replace_rules(self):
         """
-        Replace purls in the results based on the SCANOSS settings file
+        Apply BOM replace rules from the SCANOSS settings file to the scan results
         """
         to_replace_entries = self.scanoss_settings.get_bom_replace()
         if not to_replace_entries:
@@ -143,31 +143,32 @@ class ScanPostProcessor(ScanossBase):
 
         for result_path, result in self.results.items():
             entry = result[0] if isinstance(result, list) else result
-            should_replace, to_replace_with_purl = self._should_replace_result(result_path, entry, to_replace_entries)
-            if should_replace:
-                self.results[result_path] = [self._update_replaced_result(entry, to_replace_with_purl)]
+            replace_rule = self._find_replace_rule(result_path, entry, to_replace_entries)
+            if replace_rule:
+                self.results[result_path] = [self._apply_replace_rule(entry, replace_rule)]
 
-    def _update_replaced_result(self, result: dict, to_replace_with_purl: str) -> dict:
+    def _apply_replace_rule(self, result: dict, replace_rule: ReplaceRule) -> dict:
         """
         Update the result with the new purl and component information if available,
         otherwise removes the old component information
 
         Args:
             result (dict): The result to update
-            to_replace_with_purl (str): The purl to replace with
+            replace_rule (ReplaceRule): The replace rule to apply
 
         Returns:
             dict: Updated result
         """
-        if self.component_info_map.get(to_replace_with_purl):
-            result.update(self.component_info_map[to_replace_with_purl])
+        if self.component_info_map.get(replace_rule.replace_with):
+            result.update(self.component_info_map[replace_rule.replace_with])
         else:
             try:
-                new_component = PackageURL.from_string(to_replace_with_purl).to_dict()
-                new_component_url = purl2url.get_repo_url(to_replace_with_purl)
+                new_component = PackageURL.from_string(replace_rule.replace_with).to_dict()
+                new_component_url = purl2url.get_repo_url(replace_rule.replace_with)
             except RuntimeError:
                 self.print_stderr(
-                    f"ERROR: Issue while replacing: Invalid PURL '{to_replace_with_purl}' in settings file. Skipping."
+                    f"ERROR: Issue while replacing: Invalid PURL '{replace_rule.replace_with}'"
+                    ' in settings file. Skipping.'
                 )
                 return result
 
@@ -176,6 +177,8 @@ class ScanPostProcessor(ScanossBase):
             result['vendor'] = new_component.get('namespace')
 
             result.pop('licenses', None)
+            if replace_rule.license:
+                result['licenses'] = [{'name': replace_rule.license}]
             result.pop('file', None)
             result.pop('file_hash', None)
             result.pop('file_url', None)
@@ -187,14 +190,14 @@ class ScanPostProcessor(ScanossBase):
             result.pop('url_stats', None)
             result.pop('version', None)
 
-        result['purl'] = [to_replace_with_purl]
+        result['purl'] = [replace_rule.replace_with]
         result['status'] = 'identified'
 
         return result
 
-    def _should_replace_result(
+    def _find_replace_rule(
         self, result_path: str, result: dict, to_replace_entries: List[ReplaceRule]
-    ) -> Tuple[bool, str]:
+    ) -> Optional[ReplaceRule]:
         """
         Check if a result should be replaced based on the SCANOSS settings.
         Uses priority-based matching: most specific rule wins.
@@ -205,16 +208,15 @@ class ScanPostProcessor(ScanossBase):
             to_replace_entries (List[ReplaceRule]): Replace rules from the settings file
 
         Returns:
-            bool: True if the result should be replaced, False otherwise
-            str: The purl to replace with
+            Optional[ReplaceRule]: The matching replace rule, or None if no match
         """
         result_purls = result.get('purl', [])
         match = find_best_match(result_path, result_purls, to_replace_entries)
         if match and isinstance(match, ReplaceRule) and match.replace_with:
             if self.debug:
                 self._print_message(result_path, result_purls, match, 'Replacing')
-            return True, match.replace_with
-        return False, None
+            return match
+        return None
 
     def _should_remove_result(self, result_path: str, result: dict, to_remove_entries: List[BomEntry]) -> bool:
         """

--- a/tests/test_scan_post_processor.py
+++ b/tests/test_scan_post_processor.py
@@ -194,9 +194,13 @@ class MyTestCase(unittest.TestCase):
             self.assertEqual(entry['vendor'], 'scanoss')
             self.assertEqual(entry['status'], 'identified')
             self.assertEqual(entry['licenses'], [{'name': 'GPL-2.0-only'}])
-            # Old metadata should be stripped
+            # source_hash belongs to the local scanned file and must be preserved
+            self.assertIn('source_hash', entry)
+            # Old component/KB metadata should be stripped
             for field in ('file', 'file_hash', 'file_url', 'latest', 'release_date',
-                          'source_hash', 'url_hash', 'url_stats', 'version'):
+                          'url_hash', 'url_stats', 'version', 'cryptography',
+                          'vulnerabilities', 'provenance', 'dependencies', 'health',
+                          'quality'):
                 self.assertNotIn(field, entry)
         finally:
             os.unlink(path)

--- a/tests/test_scan_post_processor.py
+++ b/tests/test_scan_post_processor.py
@@ -235,6 +235,30 @@ class MyTestCase(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_replace_with_existing_purl_empty_licenses_clears_original(self):
+        """When replace_with PURL exists in scan results but has an empty
+        licenses list, the original component's licenses must be replaced
+        with the empty list — not left stale."""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/jenkins-pipeline-example',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            # inc/json.h originally had BSD-2-Clause + GPL-2.0-only licenses;
+            # jenkins-pipeline-example (from inc/log.c) has licenses: []
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/jenkins-pipeline-example'])
+            # Original licenses must NOT remain — replaced with empty list
+            self.assertEqual(entry['licenses'], [])
+        finally:
+            os.unlink(path)
+
     def test_replace_path_scoped_with_existing_purl_and_license_override(self):
         """Reproduce Sean's bug: path-scoped replace rule where replace_with PURL
         already exists in results from a different file. Per-file fields must be

--- a/tests/test_scan_post_processor.py
+++ b/tests/test_scan_post_processor.py
@@ -22,7 +22,9 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
+import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -39,6 +41,21 @@ class MyTestCase(unittest.TestCase):
     scan_settings_path = Path(script_dir, 'data', 'scanoss.json').resolve()
     scan_settings = ScanossSettings(filepath=scan_settings_path)
     post_processor = ScanPostProcessor(scan_settings)
+
+    result_json_path = Path(script_dir, 'data', 'result.json').resolve()
+
+    def _load_result_data(self):
+        """Load result.json fixture, returning a fresh dict each time."""
+        with open(self.result_json_path) as f:
+            return json.load(f)
+
+    def _make_processor(self, settings_data):
+        """Create a ScanPostProcessor from inline settings data, returns (processor, path)."""
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(settings_data, f)
+        f.close()
+        settings = ScanossSettings(filepath=Path(f.name))
+        return ScanPostProcessor(settings), f.name
 
     def test_remove_files(self):
         """
@@ -112,6 +129,93 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(
             processed_results['only_purl_match.py'][0]['purl'], ['pkg:github/scanoss/only_purl_match_replaced.py']
         )
+
+
+    def test_replace_purls_with_license(self):
+        """Should apply the license from the replace rule to the result"""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/replacement',
+                    'license': 'Apache-2.0',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/replacement'])
+            self.assertEqual(entry['licenses'], [{'name': 'Apache-2.0'}])
+        finally:
+            os.unlink(path)
+
+    def test_replace_purls_without_license(self):
+        """Should remove licenses when replace rule has no license field"""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/replacement',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/replacement'])
+            self.assertNotIn('licenses', entry)
+        finally:
+            os.unlink(path)
+
+    def test_replace_with_realistic_result(self):
+        """Should replace a full realistic scan result and strip old metadata"""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/replacement',
+                    'license': 'GPL-2.0-only',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/replacement'])
+            self.assertEqual(entry['component'], 'replacement')
+            self.assertEqual(entry['vendor'], 'scanoss')
+            self.assertEqual(entry['status'], 'identified')
+            self.assertEqual(entry['licenses'], [{'name': 'GPL-2.0-only'}])
+            # Old metadata should be stripped
+            for field in ('file', 'file_hash', 'file_url', 'latest', 'release_date',
+                          'source_hash', 'url_hash', 'url_stats', 'version'):
+                self.assertNotIn(field, entry)
+        finally:
+            os.unlink(path)
+
+    def test_replace_purl_with_version_no_match_unversioned_result(self):
+        """Should NOT replace when rule has purl@version but result has no version"""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c@1.3.3',
+                    'replace_with': 'pkg:github/scanoss/replacement@2.0.0',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            entry = processed['inc/json.h'][0]
+            # Should remain unchanged — result purl has no version
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/scanner.c'])
+            self.assertEqual(entry['status'], 'pending')
+        finally:
+            os.unlink(path)
 
 
 if __name__ == '__main__':

--- a/tests/test_scan_post_processor.py
+++ b/tests/test_scan_post_processor.py
@@ -169,8 +169,8 @@ class MyTestCase(unittest.TestCase):
             entry = processed['inc/json.h'][0]
             self.assertEqual(entry['purl'], ['pkg:github/scanoss/replacement'])
             # 'replacement' is not in scan results, so there's no license info
-            # to copy — the original component's licenses must be stripped
-            self.assertNotIn('licenses', entry)
+            # to copy — the original component's licenses must be reset to default
+            self.assertEqual(entry['licenses'], [])
         finally:
             os.unlink(path)
 
@@ -194,14 +194,23 @@ class MyTestCase(unittest.TestCase):
             self.assertEqual(entry['vendor'], 'scanoss')
             self.assertEqual(entry['status'], 'identified')
             self.assertEqual(entry['licenses'], [{'name': 'GPL-2.0-only'}])
-            # source_hash belongs to the local scanned file and must be preserved
+            # File-related fields must be preserved
             self.assertIn('source_hash', entry)
-            # Old component/KB metadata should be stripped
-            for field in ('file', 'file_hash', 'file_url', 'latest', 'release_date',
-                          'url_hash', 'url_stats', 'version', 'cryptography',
-                          'vulnerabilities', 'provenance', 'dependencies', 'health',
-                          'quality'):
-                self.assertNotIn(field, entry)
+            self.assertIn('file', entry)
+            self.assertIn('file_hash', entry)
+            self.assertIn('file_url', entry)
+            # Component-level fields should be reset to defaults
+            self.assertEqual(entry['cryptography'], [])
+            self.assertEqual(entry['dependencies'], [])
+            self.assertEqual(entry['quality'], [])
+            self.assertEqual(entry['vulnerabilities'], [])
+            self.assertEqual(entry['health'], {})
+            self.assertEqual(entry['provenance'], '')
+            self.assertEqual(entry['latest'], '')
+            self.assertEqual(entry['release_date'], '')
+            self.assertEqual(entry['version'], '')
+            self.assertEqual(entry['url_hash'], '')
+            self.assertEqual(entry['url_stats'], {})
         finally:
             os.unlink(path)
 

--- a/tests/test_scan_post_processor.py
+++ b/tests/test_scan_post_processor.py
@@ -152,7 +152,9 @@ class MyTestCase(unittest.TestCase):
             os.unlink(path)
 
     def test_replace_purls_without_license(self):
-        """Should remove licenses when replace rule has no license field"""
+        """When replace_with PURL is NOT in scan results and the rule has no
+        license override, licenses should be removed entirely — we have no
+        license info for the unknown replacement component."""
         processor, path = self._make_processor({
             'bom': {
                 'replace': [{
@@ -166,6 +168,8 @@ class MyTestCase(unittest.TestCase):
 
             entry = processed['inc/json.h'][0]
             self.assertEqual(entry['purl'], ['pkg:github/scanoss/replacement'])
+            # 'replacement' is not in scan results, so there's no license info
+            # to copy — the original component's licenses must be stripped
             self.assertNotIn('licenses', entry)
         finally:
             os.unlink(path)
@@ -199,8 +203,7 @@ class MyTestCase(unittest.TestCase):
 
     def test_replace_with_existing_purl_preserves_per_file_fields(self):
         """When replace_with target exists in scan results (component_info_map),
-        per-file fields from the original result must be preserved, not clobbered
-        by values from the component_info_map entry."""
+        per-file fields must be preserved and component-level fields copied."""
         processor, path = self._make_processor({
             'bom': {
                 'replace': [{
@@ -212,8 +215,6 @@ class MyTestCase(unittest.TestCase):
         try:
             processed = processor.load_results(self._load_result_data()).post_process()
 
-            # inc/json.h originally matched scanner.c and should now be replaced
-            # with engine, but per-file fields must stay from the original result
             entry = processed['inc/json.h'][0]
             self.assertEqual(entry['purl'], ['pkg:github/scanoss/engine'])
             self.assertEqual(entry['status'], 'identified')
@@ -228,15 +229,21 @@ class MyTestCase(unittest.TestCase):
             # Component-level fields should come from the engine entry
             self.assertEqual(entry['component'], 'engine')
             self.assertEqual(entry['vendor'], 'scanoss')
+            # Without a license override, the component's licenses are kept
+            self.assertIn('licenses', entry)
+            self.assertTrue(len(entry['licenses']) > 0)
         finally:
             os.unlink(path)
 
-    def test_replace_with_existing_purl_applies_license_override(self):
-        """When replace_with target exists in component_info_map AND the replace
-        rule has a license, the license override must be applied."""
+    def test_replace_path_scoped_with_existing_purl_and_license_override(self):
+        """Reproduce Sean's bug: path-scoped replace rule where replace_with PURL
+        already exists in results from a different file. Per-file fields must be
+        preserved, license override must be applied, and files outside the path
+        must not be affected."""
         processor, path = self._make_processor({
             'bom': {
                 'replace': [{
+                    'path': 'src/',
                     'purl': 'pkg:github/scanoss/scanner.c',
                     'replace_with': 'pkg:github/scanoss/engine',
                     'license': 'GPL-3.0-only',
@@ -246,34 +253,23 @@ class MyTestCase(unittest.TestCase):
         try:
             processed = processor.load_results(self._load_result_data()).post_process()
 
-            entry = processed['inc/json.h'][0]
+            # src/json.c is under src/ and matches scanner.c → should be replaced
+            entry = processed['src/json.c'][0]
             self.assertEqual(entry['purl'], ['pkg:github/scanoss/engine'])
-            # License override must take effect even though component_info_map
-            # has its own licenses for engine
+            self.assertEqual(entry['status'], 'identified')
             self.assertEqual(entry['licenses'], [{'name': 'GPL-3.0-only'}])
-        finally:
-            os.unlink(path)
+            # Per-file fields must be from src/json.c, not from the engine entry
+            self.assertEqual(entry['file'], 'scanner.c-1.3.3/external/src/json.c')
+            self.assertEqual(entry['file_hash'], '8e4d433c1547b59681379e9fe9960546')
+            self.assertEqual(entry['source_hash'], '8e4d433c1547b59681379e9fe9960546')
+            # Component-level fields from engine
+            self.assertEqual(entry['component'], 'engine')
+            self.assertEqual(entry['vendor'], 'scanoss')
 
-    def test_replace_with_existing_purl_keeps_component_licenses_when_no_override(self):
-        """When replace_with target exists in component_info_map and no license
-        override is specified, the component's licenses from the map are kept."""
-        processor, path = self._make_processor({
-            'bom': {
-                'replace': [{
-                    'purl': 'pkg:github/scanoss/scanner.c',
-                    'replace_with': 'pkg:github/scanoss/engine',
-                }]
-            }
-        })
-        try:
-            processed = processor.load_results(self._load_result_data()).post_process()
-
-            entry = processed['inc/json.h'][0]
-            self.assertEqual(entry['purl'], ['pkg:github/scanoss/engine'])
-            # Without a license override, the entry should have the engine's
-            # original licenses from the component_info_map
-            self.assertIn('licenses', entry)
-            self.assertTrue(len(entry['licenses']) > 0)
+            # inc/json.h is NOT under src/ → should remain unchanged
+            inc_entry = processed['inc/json.h'][0]
+            self.assertEqual(inc_entry['purl'], ['pkg:github/scanoss/scanner.c'])
+            self.assertEqual(inc_entry['status'], 'pending')
         finally:
             os.unlink(path)
 

--- a/tests/test_scan_post_processor.py
+++ b/tests/test_scan_post_processor.py
@@ -197,6 +197,86 @@ class MyTestCase(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_replace_with_existing_purl_preserves_per_file_fields(self):
+        """When replace_with target exists in scan results (component_info_map),
+        per-file fields from the original result must be preserved, not clobbered
+        by values from the component_info_map entry."""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/engine',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            # inc/json.h originally matched scanner.c and should now be replaced
+            # with engine, but per-file fields must stay from the original result
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/engine'])
+            self.assertEqual(entry['status'], 'identified')
+            # Per-file fields must be from the ORIGINAL result (inc/json.h), not
+            # from the component_info_map entry (which came from a different file)
+            self.assertEqual(entry['file'], 'scanner.c-1.3.3/external/inc/json.h')
+            self.assertEqual(entry['file_hash'], 'e91a03b850651dd56dd979ba92668a19')
+            self.assertEqual(entry['source_hash'], 'e91a03b850651dd56dd979ba92668a19')
+            self.assertEqual(entry['lines'], 'all')
+            self.assertEqual(entry['matched'], '100%')
+            self.assertEqual(entry['oss_lines'], 'all')
+            # Component-level fields should come from the engine entry
+            self.assertEqual(entry['component'], 'engine')
+            self.assertEqual(entry['vendor'], 'scanoss')
+        finally:
+            os.unlink(path)
+
+    def test_replace_with_existing_purl_applies_license_override(self):
+        """When replace_with target exists in component_info_map AND the replace
+        rule has a license, the license override must be applied."""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/engine',
+                    'license': 'GPL-3.0-only',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/engine'])
+            # License override must take effect even though component_info_map
+            # has its own licenses for engine
+            self.assertEqual(entry['licenses'], [{'name': 'GPL-3.0-only'}])
+        finally:
+            os.unlink(path)
+
+    def test_replace_with_existing_purl_keeps_component_licenses_when_no_override(self):
+        """When replace_with target exists in component_info_map and no license
+        override is specified, the component's licenses from the map are kept."""
+        processor, path = self._make_processor({
+            'bom': {
+                'replace': [{
+                    'purl': 'pkg:github/scanoss/scanner.c',
+                    'replace_with': 'pkg:github/scanoss/engine',
+                }]
+            }
+        })
+        try:
+            processed = processor.load_results(self._load_result_data()).post_process()
+
+            entry = processed['inc/json.h'][0]
+            self.assertEqual(entry['purl'], ['pkg:github/scanoss/engine'])
+            # Without a license override, the entry should have the engine's
+            # original licenses from the component_info_map
+            self.assertIn('licenses', entry)
+            self.assertTrue(len(entry['licenses']) > 0)
+        finally:
+            os.unlink(path)
+
     def test_replace_purl_with_version_no_match_unversioned_result(self):
         """Should NOT replace when rule has purl@version but result has no version"""
         processor, path = self._make_processor({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BOM replacement rules with licenses now apply the specified license to the replaced component, preserve per-file metadata when present, and always set the component identifier and identification status after replacement.

* **Refactor**
  * Replacement logic reorganized to use rule-driven processing for more consistent and maintainable behavior.

* **Tests**
  * Added unit tests covering license-applied and license-removed replacements, realistic full-result replacements, and version-mismatch no-replace scenarios.

* **Documentation**
  * CHANGELOG updated with the fix under Unreleased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->