### PR TITLE
feat(hfh):SP-4181 implement raw output format for folder hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `--format raw` option to `folder-scan` command to export HFH results in snippet-scanner JSON format
+  - Expands directory-level HFH results into per-file entries keyed by relative file path
+  - Assigns each file to the most specific matching `path_id` (deepest directory match wins)
 
 ## [1.50.1] - 2026-03-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.51.0] - 2026-03-26
 ### Added
 - Added `--format raw` option to `folder-scan` command to export HFH results in snippet-scanner JSON format
   - Expands directory-level HFH results into per-file entries keyed by relative file path
@@ -859,3 +861,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.49.0]: https://github.com/scanoss/scanoss.py/compare/v1.48.0...v1.49.0
 [1.49.1]: https://github.com/scanoss/scanoss.py/compare/v1.49.0...v1.49.1
 [1.50.0]: https://github.com/scanoss/scanoss.py/compare/v1.49.1...v1.50.0
+[1.50.1]: https://github.com/scanoss/scanoss.py/compare/v1.50.0...v1.50.1
+[1.51.0]: https://github.com/scanoss/scanoss.py/compare/v1.50.1...v1.51.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--format raw` option to `folder-scan` command to export HFH results in snippet-scanner JSON format
   - Expands directory-level HFH results into per-file entries keyed by relative file path
   - Assigns each file to the most specific matching `path_id` (deepest directory match wins)
+- Added license decoration to folder hash scan results via dependency service
+  - Each component version in HFH results is now decorated with license information
+  - CycloneDX output uses pre-decorated licenses instead of making a separate dependency API call
 
 ## [1.50.1] - 2026-03-23
 ### Fixed

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.50.1'
+__version__ = '1.51.0'

--- a/src/scanoss/cli.py
+++ b/src/scanoss/cli.py
@@ -988,7 +988,7 @@ def setup_args() -> None:  # noqa: PLR0912, PLR0915
         '--format',
         '-f',
         type=str,
-        choices=['json', 'cyclonedx'],
+        choices=['json', 'cyclonedx', 'raw'],
         default='json',
         help='Result output format (optional - default: json)',
     )

--- a/src/scanoss/scanners/scanner_hfh.py
+++ b/src/scanoss/scanners/scanner_hfh.py
@@ -22,11 +22,15 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
+import hashlib
 import json
+import os
 import threading
 import time
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
+from packageurl.contrib import purl2url
 from progress.spinner import Spinner
 
 from scanoss.constants import (
@@ -163,6 +167,13 @@ class ScannerHFHPresenter(AbstractPresenter):
     """
 
     def __init__(self, scanner: ScannerHFH, **kwargs):
+        """
+        Initialize the presenter.
+
+        Args:
+            scanner (ScannerHFH): The HFH scanner instance containing scan results and file filters.
+            **kwargs: Additional arguments passed to AbstractPresenter (debug, trace, quiet, etc.).
+        """
         super().__init__(**kwargs)
         self.scanner = scanner
 
@@ -249,4 +260,176 @@ class ScannerHFHPresenter(AbstractPresenter):
         raise NotImplementedError('CSV output is not implemented')
 
     def _format_raw_output(self) -> str:
-        raise NotImplementedError('Raw output is not implemented')
+        """
+        Convert HFH scan results into snippet-scanner JSON format.
+
+        Expands directory-level HFH results into per-file entries keyed by
+        relative file path, matching the structure returned by the snippet scanner.
+        For each file, computes the MD5 hash and constructs the file_url using
+        the API base URL from the scanner config.
+
+        Returns:
+            str: A JSON string with the snippet-scanner format, or '{}' if no results.
+        """
+        if not self.scanner.scan_results or 'results' not in self.scanner.scan_results:
+            return '{}'
+
+        hfh_results = self.scanner.scan_results.get('results', [])
+        if not hfh_results:
+            return '{}'
+
+        # Collect best-match component info per path_id
+        path_components = self._extract_best_components(hfh_results)
+        if not path_components:
+            return '{}'
+
+        # Get all filtered files once (relative paths to scan_dir)
+        all_files = self.scanner.file_filters.get_filtered_files_from_folder(self.scanner.scan_dir)
+
+        # Sort path_ids by depth (deepest first) so most-specific match wins.
+        # Root path '.' is always last (-1), others sort by separator count then path length.
+        # Example with path_ids: ['.', 'external', 'project-1.0', 'project-1.0/src/lib']
+        #   Sorted result: ['project-1.0/src/lib', 'project-1.0', 'external', '.']
+        #   - 'project-1.0/src/lib' (depth 2) claims its files first
+        #   - 'project-1.0' (depth 0, len 11) claims remaining files under it
+        #   - 'external' (depth 0, len 8) claims external/ files
+        #   - '.' (root, always last) picks up everything else
+        sorted_path_ids = sorted(
+            path_components.keys(),
+            key=lambda p: (-1, 0) if p == '.' else (p.count(os.sep), len(p)),
+            reverse=True,
+        )
+
+        output = {}
+        claimed_files = set()
+        scan_dir = Path(self.scanner.scan_dir).resolve()
+
+        for path_id in sorted_path_ids:
+            component, best_version = path_components[path_id]
+            for file_path in all_files:
+                if file_path in claimed_files:
+                    continue
+                if not self._file_matches_path_id(file_path, path_id):
+                    continue
+
+                claimed_files.add(file_path)
+                # Path.__truediv__ (/) joins paths using the correct OS separator
+                file_hash = self._compute_file_md5(scan_dir / file_path)
+                api_url = self.scanner.client.orig_url or ''
+                entry = self._build_file_match_entry(component, best_version, file_path, file_hash, api_url)
+                output[file_path] = [entry]
+
+        return json.dumps(output, indent=2)
+
+    @staticmethod
+    def _extract_best_components(hfh_results: List[Dict]) -> Dict[str, Tuple[Dict, Dict]]:
+        """
+        Extract the best-match component and version for each path_id from HFH results.
+
+        Filters for components with order == 1 (best match) and takes their first version.
+        Results without a qualifying component or without versions are skipped.
+
+        Args:
+            hfh_results (List[Dict]): The 'results' list from the HFH API response.
+
+        Returns:
+            Dict[str, Tuple[Dict, Dict]]: A dict mapping path_id to (component, best_version).
+        """
+        path_components = {}
+        for result in hfh_results:
+            path_id = result.get('path_id', '.')
+            components = result.get('components', [])
+            best = [c for c in components if c.get('order') == 1]
+            if not best:
+                continue
+            component = best[0]
+            versions = component.get('versions', [])
+            if not versions:
+                continue
+            path_components[path_id] = (component, versions[0])
+        return path_components
+
+    @staticmethod
+    def _file_matches_path_id(file_path: str, path_id: str) -> bool:
+        """
+        Check if a file path belongs under a given path_id directory.
+
+        Both file_path and path_id are relative to the scan root directory.
+        A path_id of '.' matches all files (root directory).
+
+        Args:
+            file_path (str): Relative file path from the scan root.
+            path_id (str): Relative directory path from the HFH result.
+
+        Returns:
+            bool: True if the file is under the given path_id directory.
+        """
+        if path_id == '.':
+            return True
+        # file_path and path_id are both relative to scan_dir
+        return file_path == path_id or file_path.startswith(path_id + os.sep)
+
+    def _compute_file_md5(self, file_path: Path) -> str:
+        """
+        Compute the MD5 hash of a file's contents.
+
+        Uses the same approach as the snippet scanner (winnowing.py) to ensure
+        consistent file_hash values across scan types.
+
+        Args:
+            file_path (Path): Absolute path to the file.
+
+        Returns:
+            str: The MD5 hex digest, or an empty string if the file cannot be read.
+        """
+        try:
+            return hashlib.md5(file_path.read_bytes()).hexdigest()
+        except (OSError, IOError) as e:
+            self.base.print_stderr(f'Warning: Failed to compute MD5 for {file_path}: {e}')
+            return ''
+
+    @staticmethod
+    def _build_file_match_entry(
+        component: Dict, best_version: Dict, file_path: str, file_hash: str, base_url: str,
+    ) -> Dict:
+        """
+        Build a snippet-scanner-compatible result entry from an HFH component.
+
+        Maps HFH component fields to the standard scan result format. Fields not
+        available from HFH (url_hash, release_date, licenses) are included as empty
+        values since downstream validators require them.
+
+        Args:
+            component (Dict): The HFH component with purl, name, vendor fields.
+            best_version (Dict): The top version entry with version and score fields.
+            file_path (str): Relative file path from the scan root directory.
+            file_hash (str): Pre-computed MD5 hash of the local file.
+            base_url (str): API base URL used to construct the file_url field.
+
+        Returns:
+            Dict: A result entry compatible with the snippet-scanner JSON format.
+        """
+        purl = component.get('purl', '')
+        version = best_version.get('version', '')
+
+        url = purl2url.get_repo_url(purl) if purl else ''
+        return {
+            'id': 'file',
+            'matched': '100%',
+            'purl': [purl],
+            'component': component.get('name', ''),
+            'vendor': component.get('vendor', ''),
+            'version': version,
+            'latest': version,
+            'url': url or '',
+            'file': file_path,
+            'file_hash': file_hash,
+            'file_url': f'{base_url}/file_contents/{file_hash}',
+            'source_hash': file_hash,
+            'url_hash': '',
+            'release_date': '',
+            'licenses': [],
+            'lines': 'all',
+            'oss_lines': 'all',
+            'status': 'pending',
+        }

--- a/src/scanoss/scanners/scanner_hfh.py
+++ b/src/scanoss/scanners/scanner_hfh.py
@@ -116,16 +116,107 @@ class ScannerHFH:
 
     def _execute_grpc_scan(self, hfh_request: Dict) -> None:
         """
-        Execute folder hash scan.
+        Execute folder hash scan and decorate results with license information.
 
         Args:
             hfh_request: Request dictionary for the gRPC call
         """
         try:
             self.scan_results = self.client.folder_hash_scan(hfh_request, self.use_grpc)
+            self._decorate_with_licenses()
         except Exception as e:
             self.base.print_stderr(f'Error during folder hash scan: {e}')
             self.scan_results = None
+
+    def _decorate_with_licenses(self) -> None:
+        """
+        Decorate each component version in scan results with license information
+        by calling the dependency service.
+        """
+        if not self.scan_results or not self.client:
+            return
+        results = self.scan_results.get('results', [])
+        if not results:
+            return
+
+        dep_files = self._collect_dep_files(results)
+        if not dep_files:
+            return
+
+        try:
+            decorated = self.client.get_dependencies({'files': dep_files})
+        except Exception as e:
+            self.base.print_stderr(f'Warning: Failed to fetch license data: {e}')
+            return
+
+        if not decorated or 'files' not in decorated:
+            return
+
+        license_map = self._build_license_map(decorated)
+        self._inject_licenses(results, license_map)
+
+    @staticmethod
+    def _collect_dep_files(results: List[Dict]) -> List[Dict]:
+        """Collect dependency file entries for all component versions in the results."""
+        dep_files = []
+        for result in results:
+            path_id = result.get('path_id', '')
+            for component in result.get('components', []):
+                purl = component.get('purl', '')
+                if not purl:
+                    continue
+                for version_entry in component.get('versions', []):
+                    version = version_entry.get('version', '')
+                    if not version:
+                        continue
+                    dep_files.append({
+                        'file': path_id,
+                        'purls': [{'purl': purl, 'requirement': version}],
+                    })
+        return dep_files
+
+    @staticmethod
+    def _build_license_map(decorated: Dict) -> Dict[str, List]:
+        """Build a purl@requirement -> licenses lookup from the dependency service response.
+
+        Args:
+            decorated (Dict): The response from the dependency service containing
+                decorated files with license information.
+
+        Returns:
+            Dict[str, List]: A mapping of 'purl@requirement' keys to their
+                corresponding list of license dictionaries.
+        """
+        license_map = {}
+        for dep_file in decorated.get('files', []):
+            for dep in dep_file.get('dependencies', []):
+                dep_purl = dep.get('purl', '')
+                # Use 'requirement' instead of 'version' as the key because the service
+                # may resolve a different version, but the requirement always matches what was sent.
+                dep_requirement = dep.get('requirement', '')
+                licenses = dep.get('licenses', [])
+                if dep_purl and licenses:
+                    license_map[f'{dep_purl}@{dep_requirement}'] = licenses
+        return license_map
+
+    @staticmethod
+    def _inject_licenses(results: List[Dict], license_map: Dict[str, List]) -> None:
+        """Inject licenses from the lookup map into each component version entry.
+
+        Args:
+            results (List[Dict]): The 'results' list from the HFH scan response.
+                Each result contains components with version entries that will
+                be mutated in place to include license data.
+            license_map (Dict[str, List]): A mapping of 'purl@version' keys to
+                their corresponding list of license dictionaries, as built by
+                ``_build_license_map``.
+        """
+        for result in results:
+            for component in result.get('components', []):
+                purl = component.get('purl', '')
+                for version_entry in component.get('versions', []):
+                    version = version_entry.get('version', '')
+                    version_entry['licenses'] = license_map.get(f'{purl}@{version}', [])
 
     def scan(self) -> Optional[Dict]:
         """
@@ -215,30 +306,34 @@ class ScannerHFHPresenter(AbstractPresenter):
             if not best_match_component.get('versions'):
                 self.base.print_stderr('ERROR: No versions found for best match component')
                 return ''
-
             best_match_version = best_match_component['versions'][0]
             purl = best_match_component['purl']
+            version = best_match_version['version']
+            licenses = best_match_version.get('licenses', [])
 
-            get_dependencies_json_request = {
-                'files': [
+            # Build scan_results from already-decorated HFH data
+            scan_results = {
+                f'{best_match_component["name"]}:{version}': [
                     {
-                        'file': f'{best_match_component["name"]}:{best_match_version["version"]}',
-                        'purls': [{'purl': purl, 'requirement': best_match_version['version']}],
+                        'id': 'dependency',
+                        'dependencies': [
+                            {
+                                'purl': purl,
+                                'component': best_match_component.get('name', ''),
+                                'version': version,
+                                'licenses': licenses,
+                            }
+                        ],
                     }
                 ]
             }
 
             get_vulnerabilities_json_request = {
-                'components': [{'purl': purl, 'requirement': best_match_version['version']}],
+                'components': [{'purl': purl, 'requirement': version}],
             }
-
-            decorated_scan_results = self.scanner.client.get_dependencies(get_dependencies_json_request)
             vulnerabilities = self.scanner.client.get_vulnerabilities_json(get_vulnerabilities_json_request)
 
             cdx = CycloneDx(self.base.debug)
-            scan_results = {}
-            for f in decorated_scan_results['files']:
-                scan_results[f['file']] = [f]
             success, cdx_output = cdx.produce_from_json(scan_results)
             if not success:
                 error_msg = 'ERROR: Failed to produce CycloneDX output'
@@ -250,7 +345,7 @@ class ScannerHFHPresenter(AbstractPresenter):
 
             return json.dumps(cdx_output, indent=2)
         except Exception as e:
-            self.base.print_stderr(f'ERROR: Failed to get license information: {e}')
+            self.base.print_stderr(f'ERROR: Failed to produce CycloneDX output: {e}')
             return None
 
     def _format_spdxlite_output(self) -> str:
@@ -411,6 +506,19 @@ class ScannerHFHPresenter(AbstractPresenter):
         """
         purl = component.get('purl', '')
         version = best_version.get('version', '')
+        licenses = [
+            {
+                'name': lic.get('spdx_id') or lic.get('name', ''),
+                'patent_hints': '',
+                'copyleft': '',
+                'checklist_url': '',
+                'incompatible_with': '',
+                'osadl_updated': '',
+                'source': 'component_declared',
+                'url': f"https://spdx.org/licenses/{lic['spdx_id']}.html" if lic.get('spdx_id') else '',
+            }
+            for lic in best_version.get('licenses', [])
+        ]
 
         url = purl2url.get_repo_url(purl) if purl else ''
         return {
@@ -428,7 +536,7 @@ class ScannerHFHPresenter(AbstractPresenter):
             'source_hash': file_hash,
             'url_hash': '',
             'release_date': '',
-            'licenses': [],
+            'licenses': licenses,
             'lines': 'all',
             'oss_lines': 'all',
             'status': 'pending',

--- a/tests/test_scanner_hfh.py
+++ b/tests/test_scanner_hfh.py
@@ -1,0 +1,284 @@
+"""
+SPDX-License-Identifier: MIT
+
+  Copyright (c) 2026, SCANOSS
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+"""
+
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scanoss.scanners.scanner_hfh import ScannerHFHPresenter
+
+
+class TestExtractBestComponents(unittest.TestCase):
+    """Tests for ScannerHFHPresenter._extract_best_components"""
+
+    def test_single_result_with_best_component(self):
+        hfh_results = [
+            {
+                'path_id': 'src/lib',
+                'components': [
+                    {
+                        'order': 1,
+                        'name': 'best-comp',
+                        'versions': [{'version': '1.0.0', 'score': 95}],
+                    },
+                    {
+                        'order': 2,
+                        'name': 'other-comp',
+                        'versions': [{'version': '2.0.0', 'score': 50}],
+                    },
+                ],
+            }
+        ]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        self.assertIn('src/lib', result)
+        component, version = result['src/lib']
+        self.assertEqual(component['name'], 'best-comp')
+        self.assertEqual(version['version'], '1.0.0')
+
+    def test_no_order_1_component_skipped(self):
+        hfh_results = [
+            {
+                'path_id': 'src/lib',
+                'components': [
+                    {'order': 2, 'name': 'comp', 'versions': [{'version': '1.0.0'}]},
+                ],
+            }
+        ]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        self.assertEqual(result, {})
+
+    def test_empty_components_skipped(self):
+        hfh_results = [{'path_id': 'src/lib', 'components': []}]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        self.assertEqual(result, {})
+
+    def test_component_without_versions_skipped(self):
+        hfh_results = [
+            {
+                'path_id': 'src/lib',
+                'components': [{'order': 1, 'name': 'comp', 'versions': []}],
+            }
+        ]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        self.assertEqual(result, {})
+
+    def test_default_path_id_is_dot(self):
+        hfh_results = [
+            {
+                'components': [
+                    {'order': 1, 'name': 'comp', 'versions': [{'version': '1.0'}]},
+                ],
+            }
+        ]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        self.assertIn('.', result)
+
+    def test_multiple_results(self):
+        hfh_results = [
+            {
+                'path_id': 'a',
+                'components': [
+                    {'order': 1, 'name': 'comp-a', 'versions': [{'version': '1.0'}]},
+                ],
+            },
+            {
+                'path_id': 'b',
+                'components': [
+                    {'order': 1, 'name': 'comp-b', 'versions': [{'version': '2.0'}]},
+                ],
+            },
+        ]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result['a'][0]['name'], 'comp-a')
+        self.assertEqual(result['b'][0]['name'], 'comp-b')
+
+    def test_empty_results_list(self):
+        result = ScannerHFHPresenter._extract_best_components([])
+        self.assertEqual(result, {})
+
+    def test_first_version_is_selected(self):
+        hfh_results = [
+            {
+                'path_id': '.',
+                'components': [
+                    {
+                        'order': 1,
+                        'name': 'comp',
+                        'versions': [
+                            {'version': '3.0', 'score': 100},
+                            {'version': '2.0', 'score': 80},
+                        ],
+                    },
+                ],
+            }
+        ]
+        result = ScannerHFHPresenter._extract_best_components(hfh_results)
+        _, version = result['.']
+        self.assertEqual(version['version'], '3.0')
+
+
+class TestFileMatchesPathId(unittest.TestCase):
+    """Tests for ScannerHFHPresenter._file_matches_path_id"""
+
+    def test_root_path_matches_all(self):
+        self.assertTrue(ScannerHFHPresenter._file_matches_path_id('any/file.py', '.'))
+
+    def test_exact_match(self):
+        self.assertTrue(ScannerHFHPresenter._file_matches_path_id('src/lib', 'src/lib'))
+
+    def test_file_under_path_id(self):
+        self.assertTrue(
+            ScannerHFHPresenter._file_matches_path_id(f'src/lib{os.sep}file.py', 'src/lib')
+        )
+
+    def test_file_not_under_path_id(self):
+        self.assertFalse(ScannerHFHPresenter._file_matches_path_id('other/file.py', 'src/lib'))
+
+    def test_partial_prefix_no_match(self):
+        # 'src/library' should NOT match path_id 'src/lib'
+        self.assertFalse(ScannerHFHPresenter._file_matches_path_id('src/library/file.py', 'src/lib'))
+
+    def test_empty_file_path(self):
+        self.assertFalse(ScannerHFHPresenter._file_matches_path_id('', 'src/lib'))
+
+    def test_root_path_matches_nested(self):
+        self.assertTrue(ScannerHFHPresenter._file_matches_path_id('a/b/c/d.py', '.'))
+
+
+class TestComputeFileMd5(unittest.TestCase):
+    """Tests for ScannerHFHPresenter._compute_file_md5"""
+
+    def _make_presenter(self):
+        mock_scanner = MagicMock()
+        return ScannerHFHPresenter(mock_scanner)
+
+    def test_correct_md5(self):
+        presenter = self._make_presenter()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b'hello world')
+            f.flush()
+            path = Path(f.name)
+        try:
+            expected = hashlib.md5(b'hello world').hexdigest()
+            self.assertEqual(presenter._compute_file_md5(path), expected)
+        finally:
+            os.unlink(path)
+
+    def test_empty_file(self):
+        presenter = self._make_presenter()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = Path(f.name)
+        try:
+            expected = hashlib.md5(b'').hexdigest()
+            self.assertEqual(presenter._compute_file_md5(path), expected)
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_file_returns_empty(self):
+        presenter = self._make_presenter()
+        path = Path('/nonexistent/file/that/does/not/exist.txt')
+        self.assertEqual(presenter._compute_file_md5(path), '')
+
+
+class TestBuildFileMatchEntry(unittest.TestCase):
+    """Tests for ScannerHFHPresenter._build_file_match_entry"""
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_basic_entry(self, mock_purl2url):
+        mock_purl2url.get_repo_url.return_value = 'https://github.com/vendor/comp'
+        component = {'purl': 'pkg:github/vendor/comp', 'name': 'comp', 'vendor': 'vendor'}
+        best_version = {'version': '1.0.0', 'licenses': [{'name': 'MIT'}]}
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'src/file.py', 'abc123', 'https://api.example.com'
+        )
+
+        self.assertEqual(entry['id'], 'file')
+        self.assertEqual(entry['matched'], '100%')
+        self.assertEqual(entry['purl'], ['pkg:github/vendor/comp'])
+        self.assertEqual(entry['component'], 'comp')
+        self.assertEqual(entry['vendor'], 'vendor')
+        self.assertEqual(entry['version'], '1.0.0')
+        self.assertEqual(entry['latest'], '1.0.0')
+        self.assertEqual(entry['url'], 'https://github.com/vendor/comp')
+        self.assertEqual(entry['file'], 'src/file.py')
+        self.assertEqual(entry['file_hash'], 'abc123')
+        self.assertEqual(entry['file_url'], 'https://api.example.com/file_contents/abc123')
+        self.assertEqual(entry['source_hash'], 'abc123')
+        self.assertEqual(entry['url_hash'], '')
+        self.assertEqual(entry['release_date'], '')
+        self.assertEqual(entry['licenses'], [{'name': 'MIT'}])
+        self.assertEqual(entry['lines'], 'all')
+        self.assertEqual(entry['oss_lines'], 'all')
+        self.assertEqual(entry['status'], 'pending')
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_empty_purl(self, mock_purl2url):
+        component = {'purl': '', 'name': 'comp', 'vendor': 'vendor'}
+        best_version = {'version': '1.0.0', 'licenses': []}
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'file.py', 'hash', 'https://api.example.com'
+        )
+
+        self.assertEqual(entry['purl'], [''])
+        self.assertEqual(entry['url'], '')
+        mock_purl2url.get_repo_url.assert_not_called()
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_missing_fields_use_defaults(self, mock_purl2url):
+        mock_purl2url.get_repo_url.return_value = ''
+        component = {}
+        best_version = {}
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'file.py', 'hash', 'https://api.example.com'
+        )
+
+        self.assertEqual(entry['purl'], [''])
+        self.assertEqual(entry['component'], '')
+        self.assertEqual(entry['vendor'], '')
+        self.assertEqual(entry['version'], '')
+        self.assertEqual(entry['licenses'], [])
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_purl2url_returns_none(self, mock_purl2url):
+        mock_purl2url.get_repo_url.return_value = None
+        component = {'purl': 'pkg:github/vendor/comp', 'name': 'comp', 'vendor': 'vendor'}
+        best_version = {'version': '1.0.0', 'licenses': []}
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'file.py', 'hash', 'https://api.example.com'
+        )
+
+        # url should fallback to '' when purl2url returns None/falsy
+        self.assertEqual(entry['url'], '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_scanner_hfh.py
+++ b/tests/test_scanner_hfh.py
@@ -212,7 +212,13 @@ class TestBuildFileMatchEntry(unittest.TestCase):
     def test_basic_entry(self, mock_purl2url):
         mock_purl2url.get_repo_url.return_value = 'https://github.com/vendor/comp'
         component = {'purl': 'pkg:github/vendor/comp', 'name': 'comp', 'vendor': 'vendor'}
-        best_version = {'version': '1.0.0', 'licenses': [{'name': 'MIT'}]}
+        # HFH API license format
+        best_version = {
+            'version': '1.0.0',
+            'licenses': [
+                {'name': 'MIT License', 'spdx_id': 'MIT', 'is_spdx_approved': True, 'url': 'https://spdx.org/licenses/MIT.html'},
+            ],
+        }
 
         entry = ScannerHFHPresenter._build_file_match_entry(
             component, best_version, 'src/file.py', 'abc123', 'https://api.example.com'
@@ -232,7 +238,17 @@ class TestBuildFileMatchEntry(unittest.TestCase):
         self.assertEqual(entry['source_hash'], 'abc123')
         self.assertEqual(entry['url_hash'], '')
         self.assertEqual(entry['release_date'], '')
-        self.assertEqual(entry['licenses'], [{'name': 'MIT'}])
+        # License should be transformed from HFH format to snippet-scanner format
+        self.assertEqual(len(entry['licenses']), 1)
+        lic = entry['licenses'][0]
+        self.assertEqual(lic['name'], 'MIT')
+        self.assertEqual(lic['source'], 'component_declared')
+        self.assertEqual(lic['url'], 'https://spdx.org/licenses/MIT.html')
+        self.assertEqual(lic['patent_hints'], '')
+        self.assertEqual(lic['copyleft'], '')
+        self.assertEqual(lic['checklist_url'], '')
+        self.assertEqual(lic['incompatible_with'], '')
+        self.assertEqual(lic['osadl_updated'], '')
         self.assertEqual(entry['lines'], 'all')
         self.assertEqual(entry['oss_lines'], 'all')
         self.assertEqual(entry['status'], 'pending')
@@ -265,6 +281,64 @@ class TestBuildFileMatchEntry(unittest.TestCase):
         self.assertEqual(entry['vendor'], '')
         self.assertEqual(entry['version'], '')
         self.assertEqual(entry['licenses'], [])
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_license_uses_spdx_id_as_name(self, mock_purl2url):
+        mock_purl2url.get_repo_url.return_value = ''
+        component = {'purl': 'pkg:github/v/c', 'name': 'c', 'vendor': 'v'}
+        best_version = {
+            'version': '1.0',
+            'licenses': [
+                {'name': 'GNU General Public License v2.0 only', 'spdx_id': 'GPL-2.0-only', 'is_spdx_approved': True, 'url': 'https://spdx.org/licenses/GPL-2.0-only.html'},
+            ],
+        }
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'file.py', 'hash', 'https://api.example.com'
+        )
+
+        lic = entry['licenses'][0]
+        self.assertEqual(lic['name'], 'GPL-2.0-only')
+        self.assertEqual(lic['url'], 'https://spdx.org/licenses/GPL-2.0-only.html')
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_license_without_spdx_id_falls_back_to_name(self, mock_purl2url):
+        mock_purl2url.get_repo_url.return_value = ''
+        component = {'purl': 'pkg:github/v/c', 'name': 'c', 'vendor': 'v'}
+        best_version = {
+            'version': '1.0',
+            'licenses': [{'name': 'Some Custom License'}],
+        }
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'file.py', 'hash', 'https://api.example.com'
+        )
+
+        lic = entry['licenses'][0]
+        self.assertEqual(lic['name'], 'Some Custom License')
+        self.assertEqual(lic['url'], '')
+
+    @patch('scanoss.scanners.scanner_hfh.purl2url')
+    def test_multiple_licenses_transformed(self, mock_purl2url):
+        mock_purl2url.get_repo_url.return_value = ''
+        component = {'purl': 'pkg:github/v/c', 'name': 'c', 'vendor': 'v'}
+        best_version = {
+            'version': '1.0',
+            'licenses': [
+                {'name': 'MIT License', 'spdx_id': 'MIT', 'is_spdx_approved': True, 'url': 'https://spdx.org/licenses/MIT.html'},
+                {'name': 'Apache License 2.0', 'spdx_id': 'Apache-2.0', 'is_spdx_approved': True, 'url': 'https://spdx.org/licenses/Apache-2.0.html'},
+            ],
+        }
+
+        entry = ScannerHFHPresenter._build_file_match_entry(
+            component, best_version, 'file.py', 'hash', 'https://api.example.com'
+        )
+
+        self.assertEqual(len(entry['licenses']), 2)
+        self.assertEqual(entry['licenses'][0]['name'], 'MIT')
+        self.assertEqual(entry['licenses'][0]['url'], 'https://spdx.org/licenses/MIT.html')
+        self.assertEqual(entry['licenses'][1]['name'], 'Apache-2.0')
+        self.assertEqual(entry['licenses'][1]['url'], 'https://spdx.org/licenses/Apache-2.0.html')
 
     @patch('scanoss.scanners.scanner_hfh.purl2url')
     def test_purl2url_returns_none(self, mock_purl2url):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `raw` output format for the folder-scan command (in addition to `json` and `cyclonedx`). `raw` emits per-file snippet-compatible JSON, expands directory-level matches into file-level entries, picks the most specific match per file, and includes a computed MD5 file hash. Default output remains `json`.

* **Documentation**
  * CHANGELOG updated to describe the new `raw` format and its per-file output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->