### PR TITLE
fix(cyclonedx): resolve missing vulnerabilities in folder-scan output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.51.1] - 2026-04-01
+### Fixed
+- Fixed vulnerabilities not appearing in CycloneDX output for folder-scan (`fs`) command
+
 ## [1.51.0] - 2026-03-26
 ### Added
 - Added `--format raw` option to `folder-scan` command to export HFH results in snippet-scanner JSON format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -867,3 +867,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.50.0]: https://github.com/scanoss/scanoss.py/compare/v1.49.1...v1.50.0
 [1.50.1]: https://github.com/scanoss/scanoss.py/compare/v1.50.0...v1.50.1
 [1.51.0]: https://github.com/scanoss/scanoss.py/compare/v1.50.1...v1.51.0
+[1.51.1]: https://github.com/scanoss/scanoss.py/compare/v1.51.0...v1.51.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.51.1] - 2026-04-01
 ### Fixed
 - Fixed vulnerabilities not appearing in CycloneDX output for folder-scan (`fs`) command
+- Fixed CycloneDX output without vulnerabilities being printed to stdout when using `--output` with folder-scan
 
 ## [1.51.0] - 2026-03-26
 ### Added

--- a/src/scanoss/__init__.py
+++ b/src/scanoss/__init__.py
@@ -22,4 +22,4 @@ SPDX-License-Identifier: MIT
   THE SOFTWARE.
 """
 
-__version__ = '1.51.0'
+__version__ = '1.51.1'

--- a/src/scanoss/cyclonedx.py
+++ b/src/scanoss/cyclonedx.py
@@ -352,7 +352,7 @@ class CycloneDx(ScanossBase):
             cdx_dict['vulnerabilities'] = []
 
         # Extract vulnerabilities from the response
-        vulns_list = vulnerabilities_data.get('purls', [])
+        vulns_list = vulnerabilities_data.get('components', [])
         if not vulns_list:
             return cdx_dict
 

--- a/src/scanoss/cyclonedx.py
+++ b/src/scanoss/cyclonedx.py
@@ -180,13 +180,14 @@ class CycloneDx(ScanossBase):
             success = self.produce_from_str(f.read(), output_file)
         return success
 
-    def produce_from_json(self, data: dict, output_file: str = None) -> tuple[bool, dict]:  # noqa: PLR0912
+    def produce_from_json(self, data: dict, output_file: str = None, print_output: bool = True) -> tuple[bool, dict]:  # noqa: PLR0912
         """
         Produce the CycloneDX output from the raw scan results input data
 
         Args:
             data (dict): JSON object
             output_file (str, optional): Output file (optional). Defaults to None.
+            print_output (bool, optional): Print/write output. Defaults to True.
 
         Returns:
             bool: True if successful, False otherwise
@@ -273,14 +274,15 @@ class CycloneDx(ScanossBase):
                 data['vulnerabilities'].append(vd)
             # End for loop
 
-        file = sys.stdout
-        if not output_file and self.output_file:
-            output_file = self.output_file
-        if output_file:
-            file = open(output_file, 'w')
-        print(json.dumps(data, indent=2), file=file)
-        if output_file:
-            file.close()
+        if print_output:
+            file = sys.stdout
+            if not output_file and self.output_file:
+                output_file = self.output_file
+            if output_file:
+                file = open(output_file, 'w')
+            print(json.dumps(data, indent=2), file=file)
+            if output_file:
+                file.close()
 
         return True, data
 

--- a/src/scanoss/scanners/scanner_hfh.py
+++ b/src/scanoss/scanners/scanner_hfh.py
@@ -334,7 +334,7 @@ class ScannerHFHPresenter(AbstractPresenter):
             vulnerabilities = self.scanner.client.get_vulnerabilities_json(get_vulnerabilities_json_request)
 
             cdx = CycloneDx(self.base.debug)
-            success, cdx_output = cdx.produce_from_json(scan_results)
+            success, cdx_output = cdx.produce_from_json(scan_results, print_output=False)
             if not success:
                 error_msg = 'ERROR: Failed to produce CycloneDX output'
                 self.base.print_stderr(error_msg)


### PR DESCRIPTION
## Summary
- Fixed `append_vulnerabilities` in `cyclonedx.py` reading the wrong key (`purls`) from the vulnerability API response — the correct key is `components` (per the `ComponentsVulnerabilityResponse` protobuf definition)
- This caused the `vulnerabilities` array in CycloneDX output to always be empty when using the `fs` (folder-scan) command
- Bumped version to 1.51.1

## Test plan
- [x] Verified vulnerability API response structure returns data under `components` key
- [x] Confirmed `append_vulnerabilities` correctly parses and appends 7 CVEs for OpenSSL
- [x] All 294 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vulnerabilities now appear correctly in CycloneDX output when using folder-scan (fs) mode.
  * CycloneDX export no longer omits vulnerabilities from stdout when using the --output option.

* **Chores**
  * Bumped package to v1.51.1 and added a release entry to the changelog (1.51.1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->